### PR TITLE
feat: use GitHub API and React Query to get repo stats

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "yarn build"
+  command = "npm run build"
   publish = "out"
 
 [[plugins]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"react-icons": "^4.2.0",
 				"react-is": "^17.0.2",
 				"react-live": "^2.3.0",
+				"react-query": "^3.21.0",
 				"remark-slug": "^6.1.0",
 				"styled-components": "5.3.1"
 			},
@@ -2376,12 +2377,14 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-			"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
-			"dev": true,
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+			"integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
 			"dependencies": {
 				"regenerator-runtime": "^0.13.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
@@ -4186,13 +4189,20 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"node_modules/base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+		},
+		"node_modules/big-integer": {
+			"version": "1.6.48",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+			"engines": {
+				"node": ">=0.6"
+			}
 		},
 		"node_modules/big.js": {
 			"version": "5.2.2",
@@ -4269,7 +4279,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -4284,6 +4293,21 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/broadcast-channel": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+			"integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.2",
+				"detect-node": "^2.1.0",
+				"js-sha3": "0.8.0",
+				"microseconds": "0.2.0",
+				"nano-time": "1.0.0",
+				"oblivious-set": "1.0.0",
+				"rimraf": "3.0.2",
+				"unload": "2.2.0"
 			}
 		},
 		"node_modules/brorand": {
@@ -4781,8 +4805,7 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"node_modules/console-browserify": {
 			"version": "1.2.0",
@@ -5262,6 +5285,11 @@
 			"engines": {
 				"node": ">=0.10"
 			}
+		},
+		"node_modules/detect-node": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
 		},
 		"node_modules/diffie-hellman": {
 			"version": "5.0.3",
@@ -6589,8 +6617,7 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
@@ -6749,7 +6776,6 @@
 			"version": "7.1.7",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
 			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -7217,7 +7243,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -7668,6 +7693,11 @@
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
+		},
+		"node_modules/js-sha3": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -8284,6 +8314,15 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/match-sorter": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz",
+			"integrity": "sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"remove-accents": "0.4.2"
+			}
+		},
 		"node_modules/matcher": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
@@ -8428,6 +8467,11 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/microseconds": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+			"integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
+		},
 		"node_modules/miller-rabin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -8506,7 +8550,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -8570,6 +8613,14 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"node_modules/nano-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+			"integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+			"dependencies": {
+				"big-integer": "^1.6.16"
+			}
 		},
 		"node_modules/nanoid": {
 			"version": "3.1.24",
@@ -9206,6 +9257,11 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/oblivious-set": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+			"integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
+		},
 		"node_modules/on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -9222,7 +9278,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -9433,7 +9488,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9970,6 +10024,31 @@
 				"react-native": ">=0.56"
 			}
 		},
+		"node_modules/react-query": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/react-query/-/react-query-3.21.0.tgz",
+			"integrity": "sha512-5rY5J8OD9f4EdkytjSsdCO+pqbJWKwSIMETfh/UyxqyjLURHE0IhlB+IPNPrzzu/dzK0rRxi5p0IkcCdSfizDQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.5.5",
+				"broadcast-channel": "^3.4.1",
+				"match-sorter": "^6.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react-dom": {
+					"optional": true
+				},
+				"react-native": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/react-refresh": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -10220,6 +10299,11 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/remove-accents": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+			"integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
+		},
 		"node_modules/repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
@@ -10293,7 +10377,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -11669,6 +11752,15 @@
 				"node": ">= 10.0.0"
 			}
 		},
+		"node_modules/unload": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+			"integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"detect-node": "^2.0.4"
+			}
+		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -12005,8 +12097,7 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"node_modules/xml-js": {
 			"version": "1.6.11",
@@ -13998,10 +14089,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-			"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
-			"dev": true,
+			"version": "7.15.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+			"integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -15353,13 +15443,17 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+		},
+		"big-integer": {
+			"version": "1.6.48",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
 		},
 		"big.js": {
 			"version": "5.2.2",
@@ -15418,7 +15512,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -15430,6 +15523,21 @@
 			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 			"requires": {
 				"fill-range": "^7.0.1"
+			}
+		},
+		"broadcast-channel": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+			"integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+			"requires": {
+				"@babel/runtime": "^7.7.2",
+				"detect-node": "^2.1.0",
+				"js-sha3": "0.8.0",
+				"microseconds": "0.2.0",
+				"nano-time": "1.0.0",
+				"oblivious-set": "1.0.0",
+				"rimraf": "3.0.2",
+				"unload": "2.2.0"
 			}
 		},
 		"brorand": {
@@ -15832,8 +15940,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"console-browserify": {
 			"version": "1.2.0",
@@ -16214,6 +16321,11 @@
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 			"dev": true
+		},
+		"detect-node": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
@@ -17247,8 +17359,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.3.2",
@@ -17380,7 +17491,6 @@
 			"version": "7.1.7",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
 			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -17731,7 +17841,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -18025,6 +18134,11 @@
 					}
 				}
 			}
+		},
+		"js-sha3": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -18532,6 +18646,15 @@
 			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
 			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
 		},
+		"match-sorter": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz",
+			"integrity": "sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==",
+			"requires": {
+				"@babel/runtime": "^7.12.5",
+				"remove-accents": "0.4.2"
+			}
+		},
 		"matcher": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
@@ -18639,6 +18762,11 @@
 				"picomatch": "^2.2.3"
 			}
 		},
+		"microseconds": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+			"integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
+		},
 		"miller-rabin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -18693,7 +18821,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -18751,6 +18878,14 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"nano-time": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+			"integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+			"requires": {
+				"big-integer": "^1.6.16"
+			}
 		},
 		"nanoid": {
 			"version": "3.1.24",
@@ -19288,6 +19423,11 @@
 				"es-abstract": "^1.18.2"
 			}
 		},
+		"oblivious-set": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+			"integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
+		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -19301,7 +19441,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -19467,8 +19606,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "3.1.1",
@@ -19884,6 +20022,16 @@
 				"fast-base64-decode": "^1.0.0"
 			}
 		},
+		"react-query": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/react-query/-/react-query-3.21.0.tgz",
+			"integrity": "sha512-5rY5J8OD9f4EdkytjSsdCO+pqbJWKwSIMETfh/UyxqyjLURHE0IhlB+IPNPrzzu/dzK0rRxi5p0IkcCdSfizDQ==",
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"broadcast-channel": "^3.4.1",
+				"match-sorter": "^6.0.2"
+			}
+		},
 		"react-refresh": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -20076,6 +20224,11 @@
 				"mdast-squeeze-paragraphs": "^4.0.0"
 			}
 		},
+		"remove-accents": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+			"integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
+		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
@@ -20127,7 +20280,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -21192,6 +21344,15 @@
 			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 			"dev": true
 		},
+		"unload": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+			"integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"detect-node": "^2.0.4"
+			}
+		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -21463,8 +21624,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"xml-js": {
 			"version": "1.6.11",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"react-icons": "^4.2.0",
 		"react-is": "^17.0.2",
 		"react-live": "^2.3.0",
+		"react-query": "^3.21.0",
 		"remark-slug": "^6.1.0",
 		"styled-components": "5.3.1"
 	},

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,70 @@
+import { useEffect, useState } from "react";
 import styled, { css } from "styled-components";
 
 import { breakpoint } from "utils/style";
 
+type StatsResult = {
+	stars: number;
+	forks: number;
+};
+
+type StatsQuery = {
+	owner: string;
+	repo: string;
+};
+
+const getGitHubStats = async (body: StatsQuery) => {
+	const response = await (
+		await fetch("/api/github/stats", {
+			body: JSON.stringify(body),
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+		})
+	).json();
+
+	return response;
+};
+
+/**
+ * Fetch GitHub stats from /api/github/stats
+ */
+const GitHubStats = () => {
+	const [stats, setStats] = useState<StatsResult>({
+		stars: 0,
+		forks: 0,
+	});
+
+	useEffect(() => {
+		getGitHubStats({
+			owner: "sreetamdas",
+			repo: "sreetamdas.com",
+		}).then((stats) => setStats(stats));
+	}, []);
+
+	if (!stats) return null;
+
+	return (
+		<Container>
+			<Stats>
+				<Stat>
+					<StatLabel>Stars</StatLabel>
+					<StatValue>{stats.stars}</StatValue>
+				</Stat>
+				<Stat>
+					<StatLabel>Forks</StatLabel>
+					<StatValue>{stats.forks}</StatValue>
+				</Stat>
+			</Stats>
+		</Container>
+	);
+};
+
 export const Footer = () => {
 	return (
 		<FooterContent>
+			<GitHubStats />
 			Made with <a href="https://nextjs.org">Next.js</a> &bull; View source on{" "}
 			<a href="https://github.com/sreetamdas/sreetamdas.com">Github</a>
 			<span>&bull;</span> <br />
@@ -29,4 +89,36 @@ const FooterContent = styled.div`
 			display: none;
 		`)}
 	}
+`;
+
+const Stat = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	margin-bottom: 1rem;
+`;
+
+const Stats = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 1rem;
+`;
+
+const StatLabel = styled.div`
+	font-size: 0.8rem;
+	margin-bottom: 0.5rem;
+`;
+
+const StatValue = styled.div`
+	font-size: 1.2rem;
+	font-weight: bold;
+`;
+
+const Container = styled.div`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding: 1rem;
+	/* background-color: #fafafa; */
 `;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,7 @@ import { VscRepoForked } from "react-icons/vsc";
 import { useQuery } from "react-query";
 import styled, { css } from "styled-components";
 
+import { sharedTransition } from "styles/components";
 import { breakpoint } from "utils/style";
 
 type StatsResult = {
@@ -103,6 +104,8 @@ const Stat = styled.a.attrs({
 	gap: 0.25rem;
 	color: var(--color-primary);
 
+	${sharedTransition("color, background-color")}
+
 	&:hover {
 		color: var(--color-primary-accent);
 		text-decoration: none;
@@ -122,6 +125,7 @@ const Stats = styled.div`
 const StatIcon = styled.span`
 	font-size: 1rem;
 	line-height: 1rem;
+
 	svg {
 		height: 1rem;
 		width: 1rem;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useState } from "react";
+import { FaRegStar } from "react-icons/fa";
+import { VscRepoForked } from "react-icons/vsc";
+import { useQuery } from "react-query";
 import styled, { css } from "styled-components";
 
 import { breakpoint } from "utils/style";
@@ -13,6 +15,9 @@ type StatsQuery = {
 	repo: string;
 };
 
+/**
+ * Fetch GitHub stats from /api/github/stats
+ */
 const getGitHubStats = async (body: StatsQuery) => {
 	const response = await (
 		await fetch("/api/github/stats", {
@@ -27,37 +32,34 @@ const getGitHubStats = async (body: StatsQuery) => {
 	return response;
 };
 
-/**
- * Fetch GitHub stats from /api/github/stats
- */
 const GitHubStats = () => {
-	const [stats, setStats] = useState<StatsResult>({
-		stars: 0,
-		forks: 0,
-	});
-
-	useEffect(() => {
-		getGitHubStats({
-			owner: "sreetamdas",
-			repo: "sreetamdas.com",
-		}).then((stats) => setStats(stats));
-	}, []);
-
-	if (!stats) return null;
+	const { data } = useQuery<StatsResult>(
+		["api", "github", "stats"],
+		async () =>
+			await getGitHubStats({
+				owner: "sreetamdas",
+				repo: "sreetamdas.com",
+			}),
+		{
+			staleTime: Infinity,
+		}
+	);
 
 	return (
-		<Container>
-			<Stats>
-				<Stat>
-					<StatLabel>Stars</StatLabel>
-					<StatValue>{stats.stars}</StatValue>
-				</Stat>
-				<Stat>
-					<StatLabel>Forks</StatLabel>
-					<StatValue>{stats.forks}</StatValue>
-				</Stat>
-			</Stats>
-		</Container>
+		<Stats>
+			<Stat href="https://github.com/sreetamdas/sreetamdas.com/stargazers">
+				<StatIcon>
+					<FaRegStar />
+				</StatIcon>
+				<StatValue>{data?.stars ?? "—"}</StatValue>
+			</Stat>
+			<Stat href="https://github.com/sreetamdas/sreetamdas.com/network/members">
+				<StatIcon>
+					<VscRepoForked />
+				</StatIcon>
+				<StatValue>{data?.forks ?? "—"}</StatValue>
+			</Stat>
+		</Stats>
 	);
 };
 
@@ -91,34 +93,39 @@ const FooterContent = styled.div`
 	}
 `;
 
-const Stat = styled.div`
+const Stat = styled.a.attrs({
+	target: "_blank",
+	rel: "noopener noreferrer",
+})`
+	width: max-content;
 	display: flex;
-	flex-direction: column;
 	align-items: center;
-	margin-bottom: 1rem;
+	gap: 0.25rem;
+	color: var(--color-primary);
+
+	&:hover {
+		color: var(--color-primary-accent);
+		text-decoration: none;
+	}
 `;
 
 const Stats = styled.div`
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	margin-bottom: 1rem;
-`;
-
-const StatLabel = styled.div`
-	font-size: 0.8rem;
-	margin-bottom: 0.5rem;
-`;
-
-const StatValue = styled.div`
-	font-size: 1.2rem;
-	font-weight: bold;
-`;
-
-const Container = styled.div`
-	display: flex;
+	display: grid;
+	grid-template-columns: max-content max-content;
 	justify-content: center;
+	justify-items: center;
 	align-items: center;
-	padding: 1rem;
-	/* background-color: #fafafa; */
+	gap: 1rem;
+	padding: 0.8rem 0;
 `;
+
+const StatIcon = styled.span`
+	font-size: 1rem;
+	line-height: 1rem;
+	svg {
+		height: 1rem;
+		width: 1rem;
+	}
+`;
+
+const StatValue = styled.span``;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,9 @@ import { AppProps } from "next/app";
 import Head from "next/head";
 import Script from "next/script";
 import React, { Fragment, useState } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
+import { Hydrate } from "react-query/hydration";
 import { createGlobalStyle, ThemeProvider } from "styled-components";
 
 import { Navbar } from "components/Navbar";
@@ -142,6 +145,7 @@ const initTheme = {
 };
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
+	const reactQueryClient = new QueryClient();
 	const [themeObject, setThemeObject] = useState<TThemeObjectInitial>(initTheme);
 
 	const getCSSVarValue = (variable: string) => {
@@ -170,15 +174,20 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
 			<Head>
 				<meta name="viewport" content="initial-scale=1.0, width=device-width" />
 			</Head>
-			<ThemeProvider theme={themeForContext}>
-				<GlobalStyles />
-				<FoobarWrapper>
-					<Navbar />
-					<Layout>
-						<Component {...pageProps} />
-					</Layout>
-				</FoobarWrapper>
-			</ThemeProvider>
+			<QueryClientProvider client={reactQueryClient}>
+				<Hydrate state={pageProps.dehydratedState}>
+					<ThemeProvider theme={themeForContext}>
+						<GlobalStyles />
+						<FoobarWrapper>
+							<Navbar />
+							<Layout>
+								<Component {...pageProps} />
+							</Layout>
+						</FoobarWrapper>
+					</ThemeProvider>
+				</Hydrate>
+				<ReactQueryDevtools />
+			</QueryClientProvider>
 		</Fragment>
 	);
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -44,10 +44,10 @@ const GlobalStyles = createGlobalStyle`
 	}
 
 	[data-theme="dark"] {
+		--color-primary: rgb(255, 255, 255);
 		--color-primary-accent: rgb(157, 134, 233);
 		--values-primary-accent: 157, 134, 233;
 		--color-secondary-accent: rgb(97, 218, 251);
-		--color-primary: rgb(255, 255, 255);
 		--color-background: rgb(0, 0, 0);
 		--color-inlineCode-bg: rgb(51, 51, 51);
 		--color-bg-blurred: rgba(15,10,35,0.9);

--- a/src/pages/api/github/stats.ts
+++ b/src/pages/api/github/stats.ts
@@ -1,0 +1,15 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+/**
+ * Get the stars and forks of a repository
+ */
+export default async (
+	req: NextApiRequest,
+	res: NextApiResponse<{ stars: number; forks: number }>
+) => {
+	const { owner, repo } = req.body;
+	const response = await (await fetch(`https://api.github.com/repos/${owner}/${repo}`)).json();
+
+	const { stargazers_count: stars = 0, forks = 0 } = response;
+	res.status(200).send({ stars, forks });
+};


### PR DESCRIPTION
Add this repo's stars and forks to `<Footer />`

- Create an [API route](https://nextjs.org/docs/api-routes/introduction) to retrieve stats from the [GitHub API](https://docs.github.com/en/rest)
- Use [React Query](https://react-query.tanstack.com) to call this API route when the `<Footer />` mounts

_Wish this could be done using `getStaticProps`, related discussion: https://github.com/vercel/next.js/discussions/26389_