### PR TITLE
fix: remove duplicate key in eslintrc rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,6 @@ module.exports = {
 		"no-unused-vars": "off",
 		"react/prop-types": "off",
 		"react-hooks/rules-of-hooks": "error",
-		"react/prop-types": "off",
 		"react-hooks/exhaustive-deps": "warn",
 		"react/react-in-jsx-scope": "off",
 		"react/jsx-no-undef": "off",


### PR DESCRIPTION
`.eslintrc.js` has a duplicate key in the rules: `react/prop-types`

![image_2021-10-08_19-25-06](https://user-images.githubusercontent.com/54589973/136569930-958b3a30-9237-4fec-ba7f-c684bdd13094.png)

This PR removes the duplicate key.

