### PR TITLE
fix: URL params not included for page views slug

### DIFF
--- a/src/components/ViewsCounter/index.tsx
+++ b/src/components/ViewsCounter/index.tsx
@@ -107,11 +107,11 @@ export const ViewsCounter = ({
 	const { asPath: path } = useRouter();
 
 	const { data } = useQuery<Pick<PostDetails, "view_count">>(
-		["page-details", "view", path],
+		["page-details", "view", path.split(/[?#]/)[0]],
 		async () =>
 			await (disabled
-				? getViewCount(window.location.pathname)
-				: updateAndGetViewCount(window.location.pathname)),
+				? getViewCount(path.split(/[?#]/)[0])
+				: updateAndGetViewCount(path.split(/[?#]/)[0])),
 		{
 			staleTime: Infinity,
 		}


### PR DESCRIPTION
Fixes #31 

## Proposed Changes
  - use `window.location.pathname` for adding page view. it gives us the path without the URL params
