### PR TITLE
fix: change twitter.com to x.com on the twitter profile link

### DIFF
--- a/src/lib/components/Header/NavItems.tsx
+++ b/src/lib/components/Header/NavItems.tsx
@@ -39,7 +39,7 @@ export const NavigationItems = () => (
 			</li>
 			<li>
 				<LinkTo
-					href="https://twitter.com/_SreetamDas"
+					href="https://x.com/_SreetamDas"
 					target="_blank"
 					className="flex items-center text-3xl text-foreground hover:text-primary md:text-2xl"
 				>


### PR DESCRIPTION


## Proposed Changes

  - update the Twitter profile link to the new link to skip redirecting from the old link to the new link (x.com)
