### PR TITLE
style: apply repo-wide oxfmt formatting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,6 @@ Fixes #
 
 ## Proposed Changes
 
-  -
-  -
-  -
+-
+-
+-

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,33 +1,33 @@
 {
-  "editor.quickSuggestions": {
-    "strings": true
-  },
-  "editor.defaultFormatter": "oxc.oxc-vscode",
-  "files.associations": {
-    "*.css": "tailwindcss",
-    "*.module.css": "tailwindcss"
-  },
-  "tailwindCSS.classAttributes": ["class", "className", "ngClass", "tw"],
-  "tailwindCSS.classFunctions": ["tw", "clsx", "cva", "cx", "cn"],
-  "tailwindCSS.includeLanguages": {
-    "plaintext": "html"
-  },
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
-  "oxc.enable": true,
-  "oxc.path.oxlint": "node_modules/oxlint/bin/oxlint",
-  "oxc.configPath": ".config/.oxlintrc.json",
-  "oxc.typeAware": true,
-  "oxc.lint.run": "onType",
-  "oxc.path.oxfmt": "node_modules/oxfmt/bin/oxfmt",
-  "oxc.fmt.configPath": ".config/.oxfmtrc.json",
-  "files.watcherExclude": {
-    "**/routeTree.gen.ts": true
-  },
-  "search.exclude": {
-    "**/routeTree.gen.ts": true
-  },
-  "files.readonlyInclude": {
-    "**/routeTree.gen.ts": true
-  }
+	"editor.quickSuggestions": {
+		"strings": true
+	},
+	"editor.defaultFormatter": "oxc.oxc-vscode",
+	"files.associations": {
+		"*.css": "tailwindcss",
+		"*.module.css": "tailwindcss"
+	},
+	"tailwindCSS.classAttributes": ["class", "className", "ngClass", "tw"],
+	"tailwindCSS.classFunctions": ["tw", "clsx", "cva", "cx", "cn"],
+	"tailwindCSS.includeLanguages": {
+		"plaintext": "html"
+	},
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"typescript.enablePromptUseWorkspaceTsdk": true,
+	"oxc.enable": true,
+	"oxc.path.oxlint": "node_modules/oxlint/bin/oxlint",
+	"oxc.configPath": ".config/.oxlintrc.json",
+	"oxc.typeAware": true,
+	"oxc.lint.run": "onType",
+	"oxc.path.oxfmt": "node_modules/oxfmt/bin/oxfmt",
+	"oxc.fmt.configPath": ".config/.oxfmtrc.json",
+	"files.watcherExclude": {
+		"**/routeTree.gen.ts": true
+	},
+	"search.exclude": {
+		"**/routeTree.gen.ts": true
+	},
+	"files.readonlyInclude": {
+		"**/routeTree.gen.ts": true
+	}
 }

--- a/content/blog/test-mdx-bundler.mdx
+++ b/content/blog/test-mdx-bundler.mdx
@@ -43,18 +43,18 @@ This is a "normal" [link](https://www.google.com)
 
 ```typescript highlight="1,3-5"
 const htmlEscapes = {
-	"&": "&amp;",
-	"<": "&lt;",
-	">": "&gt;",
-	// eslint-disable-next-line quotes
-	'"': "&quot;",
-	"'": "&#39;",
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  // eslint-disable-next-line quotes
+  '"': "&quot;",
+  "'": "&#39;",
 } as const;
 
 function escapeHtml(html: string) {
-	return html.replace(
-		/[&<>"']/g,
-		(chr) => htmlEscapes[chr as keyof typeof htmlEscapes],
-	);
+  return html.replace(
+    /[&<>"']/g,
+    (chr) => htmlEscapes[chr as keyof typeof htmlEscapes],
+  );
 }
 ```

--- a/drizzle/migrations/20260209104549_init/snapshot.json
+++ b/drizzle/migrations/20260209104549_init/snapshot.json
@@ -1,93 +1,87 @@
 {
-  "version": "7",
-  "dialect": "sqlite",
-  "id": "f368cc56-dbce-4c4d-8c30-b239a2fef5a1",
-  "prevIds": [
-    "00000000-0000-0000-0000-000000000000"
-  ],
-  "ddl": [
-    {
-      "name": "page_details",
-      "entityType": "tables"
-    },
-    {
-      "type": "integer",
-      "notNull": false,
-      "autoincrement": true,
-      "default": null,
-      "generated": null,
-      "name": "id",
-      "entityType": "columns",
-      "table": "page_details"
-    },
-    {
-      "type": "text",
-      "notNull": true,
-      "autoincrement": false,
-      "default": null,
-      "generated": null,
-      "name": "slug",
-      "entityType": "columns",
-      "table": "page_details"
-    },
-    {
-      "type": "integer",
-      "notNull": true,
-      "autoincrement": false,
-      "default": "0",
-      "generated": null,
-      "name": "view_count",
-      "entityType": "columns",
-      "table": "page_details"
-    },
-    {
-      "type": "integer",
-      "notNull": true,
-      "autoincrement": false,
-      "default": "0",
-      "generated": null,
-      "name": "likes",
-      "entityType": "columns",
-      "table": "page_details"
-    },
-    {
-      "type": "text",
-      "notNull": true,
-      "autoincrement": false,
-      "default": "CURRENT_TIMESTAMP",
-      "generated": null,
-      "name": "created_at",
-      "entityType": "columns",
-      "table": "page_details"
-    },
-    {
-      "type": "text",
-      "notNull": true,
-      "autoincrement": false,
-      "default": "CURRENT_TIMESTAMP",
-      "generated": null,
-      "name": "updated_at",
-      "entityType": "columns",
-      "table": "page_details"
-    },
-    {
-      "columns": [
-        "id"
-      ],
-      "nameExplicit": false,
-      "name": "page_details_pk",
-      "table": "page_details",
-      "entityType": "pks"
-    },
-    {
-      "columns": [
-        "slug"
-      ],
-      "nameExplicit": false,
-      "name": "page_details_slug_unique",
-      "entityType": "uniques",
-      "table": "page_details"
-    }
-  ],
-  "renames": []
+	"version": "7",
+	"dialect": "sqlite",
+	"id": "f368cc56-dbce-4c4d-8c30-b239a2fef5a1",
+	"prevIds": ["00000000-0000-0000-0000-000000000000"],
+	"ddl": [
+		{
+			"name": "page_details",
+			"entityType": "tables"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": true,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "page_details"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "slug",
+			"entityType": "columns",
+			"table": "page_details"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "view_count",
+			"entityType": "columns",
+			"table": "page_details"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "0",
+			"generated": null,
+			"name": "likes",
+			"entityType": "columns",
+			"table": "page_details"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "CURRENT_TIMESTAMP",
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "page_details"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "CURRENT_TIMESTAMP",
+			"generated": null,
+			"name": "updated_at",
+			"entityType": "columns",
+			"table": "page_details"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "page_details_pk",
+			"table": "page_details",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["slug"],
+			"nameExplicit": false,
+			"name": "page_details_slug_unique",
+			"entityType": "uniques",
+			"table": "page_details"
+		}
+	],
+	"renames": []
 }


### PR DESCRIPTION
## Summary
- Run `oxfmt` across the entire repo to standardise all files to the project's tab-based indentation convention
- After this PR, future feature PRs won't include formatting noise in their diffs

## Changes
Pure whitespace / formatting — no logic changes:
- **`.github/PULL_REQUEST_TEMPLATE.md`** — remove leading spaces from list items
- **`.vscode/settings.json`** — spaces to tabs
- **`content/blog/test-mdx-bundler.mdx`** — code block indentation (tabs to spaces per MDX override)
- **`drizzle/migrations/20260209104549_init/snapshot.json`** — spaces to tabs, add trailing newline
- **`vite.config.ts`** — spaces to tabs

## Context
Identified during the [Sentry integration PR review (#240)](https://github.com/sreetamdas/sreetamdas.com/pull/240) — several files had formatting changes mixed with logic changes, making review harder. This dedicated PR resolves all outstanding formatting inconsistencies in one shot.

## Validation
- `oxfmt --check .` — all 128 files pass
- `pnpm typecheck` — pass
- `pnpm build` — pass