### PR TITLE
fix: restore RepoContributors component for /credits page

### DIFF
--- a/src/lib/components/GitHub/RepoContributors.tsx
+++ b/src/lib/components/GitHub/RepoContributors.tsx
@@ -13,6 +13,7 @@ export const RepoContributors = () => {
 	const { data: contributors, isLoading } = useQuery({
 		queryFn: fetchContributors,
 		queryKey: ["repo-contributors"],
+		staleTime: Infinity,
 	});
 
 	if (isLoading) {

--- a/src/lib/components/GitHub/RepoContributors.tsx
+++ b/src/lib/components/GitHub/RepoContributors.tsx
@@ -1,0 +1,50 @@
+/**
+ * Displays avatars of non-bot contributors to the site's GitHub repo.
+ * Data is fetched server-side via createServerFn, queried client-side
+ * with useQuery so the page shell renders immediately.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { useServerFn } from "@tanstack/react-start";
+import { fetchRepoContributors } from "@/lib/domains/GitHub";
+import { LinkTo } from "@/lib/components/Anchor";
+
+export const RepoContributors = () => {
+	const fetchContributors = useServerFn(fetchRepoContributors);
+	const { data: contributors, isLoading } = useQuery({
+		queryFn: fetchContributors,
+		queryKey: ["repo-contributors"],
+	});
+
+	if (isLoading) {
+		return <p className="animate-pulse text-sm">Loading contributors...</p>;
+	}
+
+	if (!contributors || contributors.length === 0) {
+		return <p className="text-sm">No contributors found.</p>;
+	}
+
+	return (
+		<div className="flex flex-wrap gap-6 pt-4">
+			{contributors.map(
+				({ login, avatar_url, html_url }) =>
+					html_url && (
+						<LinkTo href={html_url} key={login} target="_blank">
+							<div className="flex flex-col items-center gap-1">
+								{avatar_url ? (
+									<img
+										src={avatar_url}
+										alt={login ?? ""}
+										width={128}
+										height={128}
+										className="rounded-full"
+										loading="lazy"
+									/>
+								) : null}
+								<span className="text-sm">{login}</span>
+							</div>
+						</LinkTo>
+					),
+			)}
+		</div>
+	);
+};

--- a/src/lib/components/GitHub/RepoContributors.tsx
+++ b/src/lib/components/GitHub/RepoContributors.tsx
@@ -31,16 +31,17 @@ export const RepoContributors = () => {
 						<LinkTo href={html_url} key={login} target="_blank">
 							<div className="flex flex-col items-center gap-1">
 								{avatar_url ? (
-									<img
-										src={avatar_url}
-										alt={login ?? ""}
-										width={128}
-										height={128}
-										className="rounded-full"
-										loading="lazy"
-									/>
+									<span className="rounded-global overflow-hidden">
+										<img
+											src={avatar_url}
+											alt={login ?? ""}
+											width={128}
+											height={128}
+											loading="lazy"
+										/>
+									</span>
 								) : null}
-								<span className="text-sm">{login}</span>
+								<p className="m-0 pb-2 text-sm">{login}</p>
 							</div>
 						</LinkTo>
 					),

--- a/src/lib/domains/GitHub/index.tsx
+++ b/src/lib/domains/GitHub/index.tsx
@@ -39,7 +39,7 @@ export const fetchGitHubStats = createServerFn({ method: "GET" }).handler(async 
 	return { stars, forks };
 });
 
-export async function fetchRepoContributors() {
+export const fetchRepoContributors = createServerFn({ method: "GET" }).handler(async () => {
 	const request = await fetch(
 		`${GITHUB_API_BASE_URL}/repos/${DEFAULT_REPO.owner}/${DEFAULT_REPO.repo}/contributors`,
 		{
@@ -54,8 +54,10 @@ export async function fetchRepoContributors() {
 	const data: Endpoints["GET /repos/{owner}/{repo}/contributors"]["response"]["data"] =
 		await request.json();
 
-	return data.filter(({ type, login }) => type !== "Bot" && login !== DEFAULT_REPO.owner);
-}
+	return data
+		.filter(({ type, login }) => type !== "Bot" && login !== DEFAULT_REPO.owner)
+		.map(({ login, avatar_url, html_url }) => ({ login, avatar_url, html_url }));
+});
 
 export async function fetchGist(gist_id: string) {
 	const request = await fetch(`${GITHUB_API_BASE_URL}/gists/${gist_id}`, {

--- a/src/routes/(main)/$slug.tsx
+++ b/src/routes/(main)/$slug.tsx
@@ -1,5 +1,6 @@
 import { rootPages } from "@/generated";
 import { MDXContent } from "@/lib/components/MDX";
+import { RepoContributors } from "@/lib/components/GitHub/RepoContributors";
 import { ViewsCounter } from "@/lib/components/ViewsCounter";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { isNil } from "lodash-es";
@@ -54,7 +55,7 @@ function MDXPageSlugPage() {
 			<h1 className="pt-10 pb-20 font-serif text-8xl font-bold tracking-tighter">
 				/{post.page_slug}
 			</h1>
-			<MDXContent source={post.raw} />
+			<MDXContent source={post.raw} components={{ RepoContributors }} />
 			<ViewsCounter />
 		</>
 	);


### PR DESCRIPTION
## Summary

- Restores the `RepoContributors` component that was accidentally deleted in a prior fresh-start commit
- Converts `fetchRepoContributors` from a plain async function to `createServerFn` with `useServerFn`/`useQuery` (matching the `GitHubStats` pattern in `Footer.tsx`)
- Wires the component into root page `MDXContent` via the `components` prop so `<RepoContributors />` in `credits.mdx` renders correctly

## Changes

- **New:** `src/lib/components/GitHub/RepoContributors.tsx` — displays avatars of non-bot contributors
- **Modified:** `src/lib/domains/GitHub/index.tsx` — `fetchRepoContributors` now uses `createServerFn`, maps response to only needed fields
- **Modified:** `src/routes/(main)/$slug.tsx` — passes `RepoContributors` to `MDXContent` components prop

## Verification

- `pnpm typecheck` passes
- `pnpm build` passes