### PR TITLE
fix(urls): remove trailing slash redirects and normalize view paths

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -17,8 +17,11 @@ export function absoluteUrl(urlOrPath: string) {
 }
 
 export function canonicalUrl(pathname: string) {
-	if (pathname === "/") return SITE_URL;
-	return absoluteUrl(pathname);
+	const normalizedPathname =
+		pathname !== "/" && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+
+	if (normalizedPathname === "/") return SITE_URL;
+	return absoluteUrl(normalizedPathname);
 }
 
 export function defaultOgImageUrl() {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -15,7 +15,19 @@ import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
 
 export { PresenceDurableObject } from "./lib/cloudflare/PresenceDurableObject";
 
-const serverEntry = createServerEntry({ fetch: handler.fetch });
+const serverEntry = createServerEntry({
+	fetch: (request, opts) => {
+		if (request.method === "GET" || request.method === "HEAD") {
+			const url = new URL(request.url);
+			if (url.pathname.length > 1 && url.pathname.endsWith("/")) {
+				url.pathname = url.pathname.slice(0, -1);
+				return Response.redirect(url.toString(), 308);
+			}
+		}
+
+		return handler.fetch(request, opts);
+	},
+});
 
 // Cast required: createServerEntry returns a narrower type than the
 // ExportedHandler<CloudflareEnv> that Sentry.withSentry() expects.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
 			pages: prerenderPages,
 			prerender: {
 				enabled: true,
+				autoSubfolderIndex: false,
 				crawlLinks: true,
 				autoStaticPathsDiscovery: true,
 				filter: ({ path }) => !path.startsWith("/aoc"),


### PR DESCRIPTION
## Summary
- redirect non-root trailing-slash requests (e.g. `/about/`) to slashless URLs (`/about`) at the worker edge
- normalize page-view keys so `/path` and `/path/` are counted as the same page
- normalize canonical URLs to never emit trailing slashes (except `/`)

## Why
The site currently served/recorded some routes with trailing slashes, which caused duplicate URL variants and split view counters. This change enforces a single canonical URL shape and unifies analytics/page views.

## Changes
- `src/worker.ts`
  - add 308 redirect for `GET/HEAD` requests ending with `/` (excluding root)
- `src/lib/components/ViewsCounter.tsx`
  - normalize slug/pathname before fetching/upserting views
  - normalize query key to avoid duplicate cache entries
- `src/lib/seo.ts`
  - normalize `canonicalUrl()` output to strip trailing slash for non-root paths