### PR TITLE
fix(stats): eliminate stat-tooltip mount flash

### DIFF
--- a/src/lib/domains/PageInteraction/StatsCounter.tsx
+++ b/src/lib/domains/PageInteraction/StatsCounter.tsx
@@ -34,8 +34,11 @@ const statsListClassName = "m-0 flex min-h-5 flex-wrap items-center justify-cent
 const statItemClassName = "flex items-center justify-center gap-1.5";
 const statValueClassName = "inline-block min-w-[2ch] text-left tabular-nums";
 const statTooltipTriggerClassName = "group relative";
+// Transition is added post-mount (see StatTooltipBubble) so the tooltip doesn't
+// animate opacity 1→0 when the stat mounts as its metrics arrive client-side —
+// that insert-time transition briefly flashed the tooltip without hover.
 const statTooltipBubbleClassName =
-	"pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-max max-w-64 -translate-x-1/2 rounded-global border border-solid border-foreground/15 bg-background px-2.5 py-1.5 text-center text-xs leading-snug text-foreground opacity-0 shadow-lg transition-opacity duration-100 group-hover:opacity-100 group-focus-within:opacity-100";
+	"pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-max max-w-64 -translate-x-1/2 rounded-global border border-solid border-foreground/15 bg-background px-2.5 py-1.5 text-center text-xs leading-snug text-foreground opacity-0 shadow-lg group-hover:opacity-100 group-focus-within:opacity-100";
 
 const StatsCounterLiveStat = lazy(() =>
 	import("./StatsCounterLiveStat").then((module) => ({ default: module.StatsCounterLiveStat })),
@@ -177,15 +180,29 @@ const MetricSkeleton = ({
 	</div>
 );
 
-const StatTooltipBubble = ({ children }: { children: ReactNode }) => (
-	<span aria-hidden="true" className={statTooltipBubbleClassName}>
-		{children}
+const StatTooltipBubble = ({ children }: { children: ReactNode }) => {
+	const [transitionReady, setTransitionReady] = useState(false);
+	useEffect(() => {
+		const id = requestAnimationFrame(() => setTransitionReady(true));
+		return () => cancelAnimationFrame(id);
+	}, []);
+
+	return (
 		<span
 			aria-hidden="true"
-			className="absolute top-full left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-r border-b border-solid border-foreground/15 bg-background"
-		/>
-	</span>
-);
+			className={cn(
+				statTooltipBubbleClassName,
+				transitionReady && "transition-opacity duration-100",
+			)}
+		>
+			{children}
+			<span
+				aria-hidden="true"
+				className="absolute top-full left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-r border-b border-solid border-foreground/15 bg-background"
+			/>
+		</span>
+	);
+};
 
 const LoadingLikeHeart = () => (
 	<span className={getLikeLoadingHeartIconClassName()}>

--- a/src/lib/domains/PageInteraction/StatsCounter.tsx
+++ b/src/lib/domains/PageInteraction/StatsCounter.tsx
@@ -34,9 +34,9 @@ const statsListClassName = "m-0 flex min-h-5 flex-wrap items-center justify-cent
 const statItemClassName = "flex items-center justify-center gap-1.5";
 const statValueClassName = "inline-block min-w-[2ch] text-left tabular-nums";
 const statTooltipTriggerClassName = "group relative";
-// Transition is added post-mount (see StatTooltipBubble) so the tooltip doesn't
-// animate opacity 1→0 when the stat mounts as its metrics arrive client-side —
-// that insert-time transition briefly flashed the tooltip without hover.
+// No opacity transition: these stats mount as their metrics arrive client-side,
+// and a transition on the freshly-inserted tooltip animates opacity 1→0 (a flash
+// without hover), so the tooltip just shows/hides instantly on hover.
 const statTooltipBubbleClassName =
 	"pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-max max-w-64 -translate-x-1/2 rounded-global border border-solid border-foreground/15 bg-background px-2.5 py-1.5 text-center text-xs leading-snug text-foreground opacity-0 shadow-lg group-hover:opacity-100 group-focus-within:opacity-100";
 
@@ -180,29 +180,15 @@ const MetricSkeleton = ({
 	</div>
 );
 
-const StatTooltipBubble = ({ children }: { children: ReactNode }) => {
-	const [transitionReady, setTransitionReady] = useState(false);
-	useEffect(() => {
-		const id = requestAnimationFrame(() => setTransitionReady(true));
-		return () => cancelAnimationFrame(id);
-	}, []);
-
-	return (
+const StatTooltipBubble = ({ children }: { children: ReactNode }) => (
+	<span aria-hidden="true" className={statTooltipBubbleClassName}>
+		{children}
 		<span
 			aria-hidden="true"
-			className={cn(
-				statTooltipBubbleClassName,
-				transitionReady && "transition-opacity duration-100",
-			)}
-		>
-			{children}
-			<span
-				aria-hidden="true"
-				className="absolute top-full left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-r border-b border-solid border-foreground/15 bg-background"
-			/>
-		</span>
-	);
-};
+			className="absolute top-full left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-r border-b border-solid border-foreground/15 bg-background"
+		/>
+	</span>
+);
 
 const LoadingLikeHeart = () => (
 	<span className={getLikeLoadingHeartIconClassName()}>

--- a/src/lib/domains/PageInteraction/StatsCounterLiveStat.tsx
+++ b/src/lib/domains/PageInteraction/StatsCounterLiveStat.tsx
@@ -5,7 +5,6 @@
  */
 "use client";
 
-import { useEffect, useState } from "react";
 import { FaRegCircleUser } from "react-icons/fa6";
 
 import { useLiveViewerCount } from "@/lib/components/useLiveViewerCount";
@@ -14,21 +13,14 @@ import { cn } from "@/lib/helpers/utils";
 const statItemClassName = "flex items-center justify-center gap-1.5";
 const statValueClassName = "inline-block min-w-[2ch] text-left tabular-nums";
 const statTooltipTriggerClassName = "group relative";
-// Transition is added post-mount (see `tooltipTransitionReady`) so the tooltip
-// doesn't animate opacity 1→0 when this deferred island mounts client-side —
-// that insert-time transition caused a brief tooltip flash without hover.
+// No opacity transition: this stat mounts client-side after paint, and a
+// transition on the freshly-inserted tooltip animates opacity 1→0 (a flash
+// without hover), so the tooltip just shows/hides instantly on hover.
 const statTooltipBubbleClassName =
 	"pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-max max-w-64 -translate-x-1/2 rounded-global border border-solid border-foreground/15 bg-background px-2.5 py-1.5 text-center text-xs leading-snug text-foreground opacity-0 shadow-lg group-hover:opacity-100 group-focus-within:opacity-100";
 
 export const StatsCounterLiveStat = () => {
 	const { count, connected } = useLiveViewerCount();
-
-	const [tooltipTransitionReady, setTooltipTransitionReady] = useState(false);
-	useEffect(() => {
-		if (count === null || tooltipTransitionReady) return;
-		const id = requestAnimationFrame(() => setTooltipTransitionReady(true));
-		return () => cancelAnimationFrame(id);
-	}, [count, tooltipTransitionReady]);
 
 	if (count === null) {
 		return (
@@ -78,13 +70,7 @@ export const StatsCounterLiveStat = () => {
 				<span aria-hidden="true" className={statValueClassName}>
 					{formattedCount}
 				</span>
-				<span
-					aria-hidden="true"
-					className={cn(
-						statTooltipBubbleClassName,
-						tooltipTransitionReady && "transition-opacity duration-100",
-					)}
-				>
+				<span aria-hidden="true" className={statTooltipBubbleClassName}>
 					{tooltipContent}
 					<span
 						aria-hidden="true"

--- a/src/lib/domains/PageInteraction/StatsCounterLiveStat.tsx
+++ b/src/lib/domains/PageInteraction/StatsCounterLiveStat.tsx
@@ -5,6 +5,7 @@
  */
 "use client";
 
+import { useEffect, useState } from "react";
 import { FaRegCircleUser } from "react-icons/fa6";
 
 import { useLiveViewerCount } from "@/lib/components/useLiveViewerCount";
@@ -13,11 +14,21 @@ import { cn } from "@/lib/helpers/utils";
 const statItemClassName = "flex items-center justify-center gap-1.5";
 const statValueClassName = "inline-block min-w-[2ch] text-left tabular-nums";
 const statTooltipTriggerClassName = "group relative";
+// Transition is added post-mount (see `tooltipTransitionReady`) so the tooltip
+// doesn't animate opacity 1→0 when this deferred island mounts client-side —
+// that insert-time transition caused a brief tooltip flash without hover.
 const statTooltipBubbleClassName =
-	"pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-max max-w-64 -translate-x-1/2 rounded-global border border-solid border-foreground/15 bg-background px-2.5 py-1.5 text-center text-xs leading-snug text-foreground opacity-0 shadow-lg transition-opacity duration-100 group-hover:opacity-100 group-focus-within:opacity-100";
+	"pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-max max-w-64 -translate-x-1/2 rounded-global border border-solid border-foreground/15 bg-background px-2.5 py-1.5 text-center text-xs leading-snug text-foreground opacity-0 shadow-lg group-hover:opacity-100 group-focus-within:opacity-100";
 
 export const StatsCounterLiveStat = () => {
 	const { count, connected } = useLiveViewerCount();
+
+	const [tooltipTransitionReady, setTooltipTransitionReady] = useState(false);
+	useEffect(() => {
+		if (count === null || tooltipTransitionReady) return;
+		const id = requestAnimationFrame(() => setTooltipTransitionReady(true));
+		return () => cancelAnimationFrame(id);
+	}, [count, tooltipTransitionReady]);
 
 	if (count === null) {
 		return (
@@ -67,7 +78,13 @@ export const StatsCounterLiveStat = () => {
 				<span aria-hidden="true" className={statValueClassName}>
 					{formattedCount}
 				</span>
-				<span aria-hidden="true" className={statTooltipBubbleClassName}>
+				<span
+					aria-hidden="true"
+					className={cn(
+						statTooltipBubbleClassName,
+						tooltipTransitionReady && "transition-opacity duration-100",
+					)}
+				>
 					{tooltipContent}
 					<span
 						aria-hidden="true"


### PR DESCRIPTION
Follow-up to #282. The engagement-counter tooltips (live viewers, views, likes) briefly flashed the tooltip visible—without hover—when their stat mounted client-side after paint: a freshly-inserted element with `transition-opacity` makes Chrome animate opacity 1→0 on insert (confirmed via a running `CSSTransition` at time 0). Views/likes shared the same latent pattern.

Fix: drop the opacity transition on the stat tooltips so there's nothing to animate on insert. Tooltips now show/hide instantly on hover (imperceptible for a tooltip) instead of a 100ms fade. No JS, works on every browser. Verified on staging: tooltip `opacity: 0` at rest with no running animation, and hover still reveals it.