### PR TITLE
feat(analytics): proxy native tracker via /api/prxy/nltyx

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -42,6 +42,8 @@ import { Route as apiApiFoobarCookieRouteImport } from './routes/(api)/api/fooba
 import { Route as apiApiLoginProviderRouteImport } from './routes/(api)/api/login/$provider'
 import { Route as mainfoobarFoobarIndexRouteImport } from './routes/(main)/(foobar)/foobar/index'
 import { Route as mainfoobarFoobarSlugRouteRouteImport } from './routes/(main)/(foobar)/foobar/$slug/route'
+import { Route as apiApiPrxyNltyxIndexRouteImport } from './routes/(api)/api/prxy/nltyx/index'
+import { Route as apiApiPrxyNltyxEventRouteImport } from './routes/(api)/api/prxy/nltyx/event'
 import { Route as apiApiSlidesSessionSessionIdRouteImport } from './routes/(api)/api/slides/session/$sessionId'
 import { Route as mainfoobarFoobarCertificateTokenRouteImport } from './routes/(main)/(foobar)/foobar/certificate/$token'
 import { Route as apiApiFoobarCertificateTokenOgDotpngRouteImport } from './routes/(api)/api/foobar/certificate/$token/og[.]png'
@@ -213,6 +215,16 @@ const mainfoobarFoobarSlugRouteRoute =
     path: '/$slug',
     getParentRoute: () => mainfoobarFoobarRouteRoute,
   } as any)
+const apiApiPrxyNltyxIndexRoute = apiApiPrxyNltyxIndexRouteImport.update({
+  id: '/(api)/api/prxy/nltyx/',
+  path: '/api/prxy/nltyx/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const apiApiPrxyNltyxEventRoute = apiApiPrxyNltyxEventRouteImport.update({
+  id: '/(api)/api/prxy/nltyx/event',
+  path: '/api/prxy/nltyx/event',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const apiApiSlidesSessionSessionIdRoute =
   apiApiSlidesSessionSessionIdRouteImport.update({
     id: '/(api)/api/slides/session/$sessionId',
@@ -264,8 +276,10 @@ export interface FileRoutesByFullPath {
   '/api/foobar/cookie': typeof apiApiFoobarCookieRoute
   '/api/login/$provider': typeof apiApiLoginProviderRoute
   '/foobar/': typeof mainfoobarFoobarIndexRoute
+  '/api/prxy/nltyx/event': typeof apiApiPrxyNltyxEventRoute
   '/api/slides/session/$sessionId': typeof apiApiSlidesSessionSessionIdRoute
   '/foobar/certificate/$token': typeof mainfoobarFoobarCertificateTokenRoute
+  '/api/prxy/nltyx/': typeof apiApiPrxyNltyxIndexRoute
   '/api/foobar/certificate/$token/og.png': typeof apiApiFoobarCertificateTokenOgDotpngRoute
 }
 export interface FileRoutesByTo {
@@ -297,8 +311,10 @@ export interface FileRoutesByTo {
   '/api/foobar/cookie': typeof apiApiFoobarCookieRoute
   '/api/login/$provider': typeof apiApiLoginProviderRoute
   '/foobar': typeof mainfoobarFoobarIndexRoute
+  '/api/prxy/nltyx/event': typeof apiApiPrxyNltyxEventRoute
   '/api/slides/session/$sessionId': typeof apiApiSlidesSessionSessionIdRoute
   '/foobar/certificate/$token': typeof mainfoobarFoobarCertificateTokenRoute
+  '/api/prxy/nltyx': typeof apiApiPrxyNltyxIndexRoute
   '/api/foobar/certificate/$token/og.png': typeof apiApiFoobarCertificateTokenOgDotpngRoute
 }
 export interface FileRoutesById {
@@ -336,8 +352,10 @@ export interface FileRoutesById {
   '/(api)/api/foobar/cookie': typeof apiApiFoobarCookieRoute
   '/(api)/api/login/$provider': typeof apiApiLoginProviderRoute
   '/(main)/(foobar)/foobar/': typeof mainfoobarFoobarIndexRoute
+  '/(api)/api/prxy/nltyx/event': typeof apiApiPrxyNltyxEventRoute
   '/(api)/api/slides/session/$sessionId': typeof apiApiSlidesSessionSessionIdRoute
   '/(main)/(foobar)/foobar/certificate/$token': typeof mainfoobarFoobarCertificateTokenRoute
+  '/(api)/api/prxy/nltyx/': typeof apiApiPrxyNltyxIndexRoute
   '/(api)/api/foobar/certificate/$token/og.png': typeof apiApiFoobarCertificateTokenOgDotpngRoute
 }
 export interface FileRouteTypes {
@@ -374,8 +392,10 @@ export interface FileRouteTypes {
     | '/api/foobar/cookie'
     | '/api/login/$provider'
     | '/foobar/'
+    | '/api/prxy/nltyx/event'
     | '/api/slides/session/$sessionId'
     | '/foobar/certificate/$token'
+    | '/api/prxy/nltyx/'
     | '/api/foobar/certificate/$token/og.png'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -407,8 +427,10 @@ export interface FileRouteTypes {
     | '/api/foobar/cookie'
     | '/api/login/$provider'
     | '/foobar'
+    | '/api/prxy/nltyx/event'
     | '/api/slides/session/$sessionId'
     | '/foobar/certificate/$token'
+    | '/api/prxy/nltyx'
     | '/api/foobar/certificate/$token/og.png'
   id:
     | '__root__'
@@ -445,8 +467,10 @@ export interface FileRouteTypes {
     | '/(api)/api/foobar/cookie'
     | '/(api)/api/login/$provider'
     | '/(main)/(foobar)/foobar/'
+    | '/(api)/api/prxy/nltyx/event'
     | '/(api)/api/slides/session/$sessionId'
     | '/(main)/(foobar)/foobar/certificate/$token'
+    | '/(api)/api/prxy/nltyx/'
     | '/(api)/api/foobar/certificate/$token/og.png'
   fileRoutesById: FileRoutesById
 }
@@ -462,7 +486,9 @@ export interface RootRouteChildren {
   apiApiAuthSplatRoute: typeof apiApiAuthSplatRoute
   apiApiFoobarCookieRoute: typeof apiApiFoobarCookieRoute
   apiApiLoginProviderRoute: typeof apiApiLoginProviderRoute
+  apiApiPrxyNltyxEventRoute: typeof apiApiPrxyNltyxEventRoute
   apiApiSlidesSessionSessionIdRoute: typeof apiApiSlidesSessionSessionIdRoute
+  apiApiPrxyNltyxIndexRoute: typeof apiApiPrxyNltyxIndexRoute
   apiApiFoobarCertificateTokenOgDotpngRoute: typeof apiApiFoobarCertificateTokenOgDotpngRoute
 }
 
@@ -699,6 +725,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof mainfoobarFoobarSlugRouteRouteImport
       parentRoute: typeof mainfoobarFoobarRouteRoute
     }
+    '/(api)/api/prxy/nltyx/': {
+      id: '/(api)/api/prxy/nltyx/'
+      path: '/api/prxy/nltyx'
+      fullPath: '/api/prxy/nltyx/'
+      preLoaderRoute: typeof apiApiPrxyNltyxIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/(api)/api/prxy/nltyx/event': {
+      id: '/(api)/api/prxy/nltyx/event'
+      path: '/api/prxy/nltyx/event'
+      fullPath: '/api/prxy/nltyx/event'
+      preLoaderRoute: typeof apiApiPrxyNltyxEventRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/(api)/api/slides/session/$sessionId': {
       id: '/(api)/api/slides/session/$sessionId'
       path: '/api/slides/session/$sessionId'
@@ -853,7 +893,9 @@ const rootRouteChildren: RootRouteChildren = {
   apiApiAuthSplatRoute: apiApiAuthSplatRoute,
   apiApiFoobarCookieRoute: apiApiFoobarCookieRoute,
   apiApiLoginProviderRoute: apiApiLoginProviderRoute,
+  apiApiPrxyNltyxEventRoute: apiApiPrxyNltyxEventRoute,
   apiApiSlidesSessionSessionIdRoute: apiApiSlidesSessionSessionIdRoute,
+  apiApiPrxyNltyxIndexRoute: apiApiPrxyNltyxIndexRoute,
   apiApiFoobarCertificateTokenOgDotpngRoute:
     apiApiFoobarCertificateTokenOgDotpngRoute,
 }

--- a/src/routes/(api)/api/prxy/nltyx/event.ts
+++ b/src/routes/(api)/api/prxy/nltyx/event.ts
@@ -1,0 +1,54 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { env } from "cloudflare:workers";
+
+export function handleAnalyticsEventGet(): Response {
+	return new Response("Method not allowed", {
+		status: 405,
+		headers: { Allow: "POST" },
+	});
+}
+
+export async function handleAnalyticsEventPost(request: Request): Promise<Response> {
+	const relayToken =
+		"RELAY_TOKEN" in env && typeof env.RELAY_TOKEN === "string" ? env.RELAY_TOKEN : "";
+	const projectSlug =
+		"ANALYTICS_PROJECT_SLUG" in env && typeof env.ANALYTICS_PROJECT_SLUG === "string"
+			? env.ANALYTICS_PROJECT_SLUG
+			: "";
+	if (relayToken.trim() === "" || projectSlug.trim() === "") {
+		return new Response("Analytics unavailable", { status: 503 });
+	}
+
+	const cf = request.cf;
+	const ip = request.headers.get("cf-connecting-ip");
+	try {
+		const response = await env.STATS.fetch(
+			`https://stats.internal/v1/relay/${encodeURIComponent(projectSlug)}`,
+			{
+				method: "POST",
+				headers: {
+					"content-type": request.headers.get("content-type") ?? "text/plain;charset=UTF-8",
+					"x-relay-token": relayToken,
+					"x-relay-ua": request.headers.get("user-agent") ?? "",
+					"x-relay-country": typeof cf?.country === "string" ? cf.country : "",
+					"x-relay-city": typeof cf?.city === "string" ? cf.city : "",
+					...(ip === null ? {} : { "x-relay-ip": ip }),
+				},
+				body: request.body,
+			},
+		);
+		if (response.status === 202) return new Response(null, { status: 202 });
+		return new Response("Analytics rejected", { status: 502 });
+	} catch {
+		return new Response("Analytics unavailable", { status: 502 });
+	}
+}
+
+export const Route = createFileRoute("/(api)/api/prxy/nltyx/event")({
+	server: {
+		handlers: {
+			POST: ({ request }) => handleAnalyticsEventPost(request),
+			GET: () => handleAnalyticsEventGet(),
+		},
+	},
+});

--- a/src/routes/(api)/api/prxy/nltyx/index.ts
+++ b/src/routes/(api)/api/prxy/nltyx/index.ts
@@ -1,0 +1,22 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { env } from "cloudflare:workers";
+
+export async function handleTrackerGet(): Promise<Response> {
+	try {
+		const response = await env.STATS.fetch("https://stats.internal/v1/nltyx.js");
+		return new Response(response.body, {
+			status: response.status,
+			headers: response.headers,
+		});
+	} catch {
+		return new Response("Tracker unavailable", { status: 502 });
+	}
+}
+
+export const Route = createFileRoute("/(api)/api/prxy/nltyx/")({
+	server: {
+		handlers: {
+			GET: () => handleTrackerGet(),
+		},
+	},
+});

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -120,9 +120,9 @@ export const Route = createRootRoute({
 		scripts: [
 			{
 				async: true,
-				"data-endpoint": "/api/analytics",
+				"data-endpoint": "/api/prxy/nltyx",
 				"data-key": "event",
-				src: "/api/analytics/tracker",
+				src: "/api/prxy/nltyx",
 			},
 		],
 	}),


### PR DESCRIPTION
Moves native tracker off blocked keywords, like the Plausible `/prxy/plsbl` pattern.

**What**
- Canonical stats tracker is `GET https://stats.sreetamdas.com/v1/nltyx.js` (opaque, not `tracker.js`/`analytics`). `GET /v1/tracker.js` kept as alias for cached HTML.
- Adds first-party proxy `GET /api/prxy/nltyx` → `stats /v1/nltyx.js` and `POST /api/prxy/nltyx/event` → `STATS.fetch /v1/relay/{slug}`. Keeps existing `GET/POST /api/analytics/*` as aliases.
- `__root.tsx` `data-endpoint/src` now `/api/prxy/nltyx` (was `/api/analytics`). `nmtyx` + `prxy` contain no `analytics/tracker/plausible/collect` token (EasyPrivacy).

**Why**
`analytics` and `tracker.js` are hit by EasyPrivacy 30%+. `/api/prxy/nltyx` mirrors the existing Plausible proxy that already evades.

**Verify**
- `pnpm build` pass, `GET /api/prxy/nltyx` 200 `application/javascript`, `POST /api/prxy/nltyx/event` 202, old paths still 200/202.