### PR TITLE
feat(security): harden view counter and analytics ingestion

### DIFF
--- a/src/cloudflare-env.d.ts
+++ b/src/cloudflare-env.d.ts
@@ -4,9 +4,15 @@
 interface __BaseEnv_CloudflareEnv {
 	KV: KVNamespace;
 	D1: D1Database;
+	VIEW_RATE_LIMITER: RateLimit;
+	VIEW_REPLAY_LIMITER: RateLimit;
 	STATS: Fetcher;
 	STATS_RPC: Service;
 	ANALYTICS_PROJECT_SLUG: string;
+	ANALYTICS_ALLOWED_ORIGINS:
+		| "https://dev.sreetamdas.com,https://staging.sreetamdas.com"
+		| "https://sreetamdas.com"
+		| "https://sreetamdas.com,http://localhost:3000,http://localhost:5173";
 	RELAY_TOKEN: string;
 	VITE_SITE_URL: string;
 	BETTER_AUTH_URL: string;
@@ -48,6 +54,8 @@ declare namespace Cloudflare {
 	interface StagingEnv {
 		KV: KVNamespace;
 		D1: D1Database;
+		VIEW_RATE_LIMITER: RateLimit;
+		VIEW_REPLAY_LIMITER: RateLimit;
 		VITE_SITE_URL: string;
 		BETTER_AUTH_URL: string;
 		DEBUG_MODE: string;
@@ -80,6 +88,8 @@ declare namespace Cloudflare {
 	interface ProductionEnv {
 		KV: KVNamespace;
 		D1: D1Database;
+		VIEW_RATE_LIMITER: RateLimit;
+		VIEW_REPLAY_LIMITER: RateLimit;
 		VITE_SITE_URL: string;
 		BETTER_AUTH_URL: string;
 		DEBUG_MODE: string;

--- a/src/lib/analytics/browser-request.ts
+++ b/src/lib/analytics/browser-request.ts
@@ -1,0 +1,27 @@
+/**
+ * Browser write boundaries use configured origins, never forwarded host headers.
+ * Origin/Fetch Metadata stop browser cross-site abuse, not clients spoofing headers.
+ */
+export function isAllowedBrowserWrite(request: Request, configuredOrigins?: string): boolean {
+	if (request.method !== "POST" || !configuredOrigins) return false;
+	const origin = request.headers.get("origin");
+	if (!origin || origin === "null") return false;
+	const allowedOrigins = configuredOrigins.split(",").map((value) => value.trim());
+	if (!allowedOrigins.includes(origin) || new URL(request.url).origin !== origin) return false;
+	const site = request.headers.get("sec-fetch-site");
+	if (site !== null && site !== "same-origin") return false;
+	const mode = request.headers.get("sec-fetch-mode");
+	if (mode === "navigate") return false;
+	const destination = request.headers.get("sec-fetch-dest");
+	return destination === null || destination === "empty";
+}
+
+export function isAutomatedBrowser(ua: string): boolean {
+	return (
+		!ua.trim() ||
+		ua.length > 2048 ||
+		/bot\b|crawler|spider|headless|puppeteer|playwright|phantomjs|selenium|cypress|lighthouse|pingdom|uptimerobot|curl\/|wget|python|go-http-client|java\/|scrapy|node-fetch|undici|axios\//i.test(
+			ua,
+		)
+	);
+}

--- a/src/lib/analytics/event.server.ts
+++ b/src/lib/analytics/event.server.ts
@@ -1,0 +1,50 @@
+/** Shared first-party relay; reject foreign browser writes before touching the body or binding. */
+import { env } from "cloudflare:workers";
+
+import { isAllowedBrowserWrite } from "./browser-request";
+
+export function handleAnalyticsEventGet(): Response {
+	return new Response("Method not allowed", {
+		status: 405,
+		headers: { Allow: "POST" },
+	});
+}
+
+export async function handleAnalyticsEventPost(request: Request): Promise<Response> {
+	if (!isAllowedBrowserWrite(request, env.ANALYTICS_ALLOWED_ORIGINS)) {
+		return new Response("Analytics rejected", { status: 403 });
+	}
+	const relayToken =
+		"RELAY_TOKEN" in env && typeof env.RELAY_TOKEN === "string" ? env.RELAY_TOKEN : "";
+	const projectSlug =
+		"ANALYTICS_PROJECT_SLUG" in env && typeof env.ANALYTICS_PROJECT_SLUG === "string"
+			? env.ANALYTICS_PROJECT_SLUG
+			: "";
+	if (relayToken.trim() === "" || projectSlug.trim() === "") {
+		return new Response("Analytics unavailable", { status: 503 });
+	}
+
+	const cf = request.cf;
+	const ip = request.headers.get("cf-connecting-ip");
+	try {
+		const response = await env.STATS.fetch(
+			`https://stats.internal/v1/relay/${encodeURIComponent(projectSlug)}`,
+			{
+				method: "POST",
+				headers: {
+					"content-type": request.headers.get("content-type") ?? "text/plain;charset=UTF-8",
+					"x-relay-token": relayToken,
+					"x-relay-ua": request.headers.get("user-agent") ?? "",
+					"x-relay-country": typeof cf?.country === "string" ? cf.country : "",
+					"x-relay-city": typeof cf?.city === "string" ? cf.city : "",
+					...(ip === null ? {} : { "x-relay-ip": ip }),
+				},
+				body: request.body,
+			},
+		);
+		if (response.status === 202) return new Response(null, { status: 202 });
+		return new Response("Analytics rejected", { status: 502 });
+	} catch {
+		return new Response("Analytics unavailable", { status: 502 });
+	}
+}

--- a/src/lib/domains/PageInteraction/ViewRecorder.data.server.test.ts
+++ b/src/lib/domains/PageInteraction/ViewRecorder.data.server.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getRequest: vi.fn(),
+	getDb: vi.fn(),
+	upsertPageViews: vi.fn(),
+	env: {
+		ANALYTICS_ALLOWED_ORIGINS: "https://sreetamdas.com",
+		LIKES_IP_SALT: "test-salt",
+		VIEW_RATE_LIMITER: { limit: vi.fn() },
+		VIEW_REPLAY_LIMITER: { limit: vi.fn() },
+	},
+}));
+vi.mock("@tanstack/react-start/server", () => ({ getRequest: mocks.getRequest }));
+vi.mock("cloudflare:workers", () => ({ env: mocks.env }));
+vi.mock("@/db", () => ({ getDb: mocks.getDb }));
+vi.mock("@/lib/domains/PageViews", () => ({ upsertPageViews: mocks.upsertPageViews }));
+vi.mock("./ViewRecorder.pages.server", () => ({ isKnownViewPage: (path: string) => path === "/" }));
+import { recordPageViewInDb } from "./ViewRecorder.data.server";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mocks.env.VIEW_RATE_LIMITER.limit.mockResolvedValue({ success: true });
+	mocks.env.VIEW_REPLAY_LIMITER.limit.mockResolvedValue({ success: true });
+	mocks.getDb.mockReturnValue("db");
+	mocks.getRequest.mockReturnValue(
+		new Request("https://sreetamdas.com/_serverFn/test", {
+			method: "POST",
+			headers: {
+				origin: "https://sreetamdas.com",
+				"user-agent": "Mozilla Chrome/140",
+				"cf-connecting-ip": "192.0.2.1",
+			},
+		}),
+	);
+});
+
+test("runtime rejected request never opens D1", async () => {
+	mocks.env.VIEW_REPLAY_LIMITER.limit.mockResolvedValue({ success: false });
+	expect(await recordPageViewInDb({ slug: "/", disabled: false })).toEqual({ recorded: false });
+	expect(mocks.getDb).not.toHaveBeenCalled();
+	expect(mocks.upsertPageViews).not.toHaveBeenCalled();
+});
+
+test("unknown pathname cannot create a counter row", async () => {
+	expect(await recordPageViewInDb({ slug: "/made-up", disabled: false })).toEqual({
+		recorded: false,
+	});
+	expect(mocks.getDb).not.toHaveBeenCalled();
+	expect(mocks.env.VIEW_RATE_LIMITER.limit).not.toHaveBeenCalled();
+});
+
+test("accepted runtime request writes once", async () => {
+	expect(await recordPageViewInDb({ slug: "/", disabled: false })).toEqual({ recorded: true });
+	expect(mocks.upsertPageViews).toHaveBeenCalledExactlyOnceWith("db", "/");
+});

--- a/src/lib/domains/PageInteraction/ViewRecorder.data.server.ts
+++ b/src/lib/domains/PageInteraction/ViewRecorder.data.server.ts
@@ -1,0 +1,17 @@
+/** Server-only request facts and content allowlist; no D1 access until every guard accepts. */
+import "@tanstack/react-start/server-only";
+import { getRequest } from "@tanstack/react-start/server";
+import { env } from "cloudflare:workers";
+
+import { getDb } from "@/db";
+import { upsertPageViews } from "@/lib/domains/PageViews";
+
+import { type PagePathnamePayload } from "./shared";
+import { isKnownViewPage } from "./ViewRecorder.pages.server";
+import { recordPageView } from "./ViewRecorder.server";
+
+export async function recordPageViewInDb(data: PagePathnamePayload) {
+	return recordPageView(data, getRequest(), env, isKnownViewPage, async (slug) => {
+		await upsertPageViews(getDb(), slug);
+	});
+}

--- a/src/lib/domains/PageInteraction/ViewRecorder.pages.server.test.ts
+++ b/src/lib/domains/PageInteraction/ViewRecorder.pages.server.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("content-collections", () => ({
+	allBlogPosts: [
+		{ page_path: "/blog/published-post", published: true },
+		{ page_path: "/blog/draft", published: false },
+	],
+	allRootPages: [
+		{ page_path: "/credits", published: true },
+		{ page_path: "/hidden", published: true, skip_page: true },
+	],
+}));
+vi.mock("@/lib/domains/Buttondown", () => ({
+	getNewsletterSnapshot: () => ({ results: [{ slug: "real-issue" }] }),
+}));
+
+import { isKnownViewPage } from "./ViewRecorder.pages.server";
+
+describe("isKnownViewPage", () => {
+	test.each([
+		"/",
+		"/about",
+		"/stats",
+		"/resume",
+		"/foobar",
+		"/slides/tanstack-start",
+		"/blog/published-post",
+		"/credits",
+		"/newsletter/real-issue",
+	])("allows routable %s", (path) => expect(isKnownViewPage(path)).toBe(true));
+	test.each([
+		"/bogus",
+		"/blog/bogus",
+		"/blog/draft",
+		"/hidden",
+		"/newsletter/bogus",
+		"/api/analytics/event",
+		"/assets/a.js",
+		"/foobar/certificate/arbitrary",
+	])("rejects %s", (path) => expect(isKnownViewPage(path)).toBe(false));
+});

--- a/src/lib/domains/PageInteraction/ViewRecorder.pages.server.ts
+++ b/src/lib/domains/PageInteraction/ViewRecorder.pages.server.ts
@@ -1,0 +1,40 @@
+/**
+ * Count only real pages, not caller-created counter keys. Static pages with
+ * counters are explicit; dynamic pages follow the same published content and
+ * committed newsletter snapshot used by the routes, without remote lookups.
+ */
+import "@tanstack/react-start/server-only";
+import { allBlogPosts, allRootPages } from "content-collections";
+
+import { shouldServeRootPage } from "@/lib/content/visibility";
+import { getNewsletterSnapshot } from "@/lib/domains/Buttondown";
+
+const staticViewPages = new Set([
+	"/",
+	"/about",
+	"/blog",
+	"/karma",
+	"/rwc",
+	"/newsletter",
+	"/keebs",
+	"/stats",
+	"/foobar",
+	"/resume",
+	"/version",
+	"/fancy-pants",
+	"/slides",
+	"/slides/json-schema-form",
+	"/slides/tanstack-start",
+	"/slides/tanstack-start/dev-lab",
+]);
+const contentViewPages = new Set([
+	...allBlogPosts.filter((post) => post.published).map((post) => post.page_path),
+	...allRootPages
+		.filter((page) => shouldServeRootPage(page, { includeDrafts: false }))
+		.map((page) => page.page_path),
+	...(getNewsletterSnapshot()?.results ?? []).map((issue) => `/newsletter/${issue.slug}`),
+]);
+
+export function isKnownViewPage(pathname: string): boolean {
+	return staticViewPages.has(pathname) || contentViewPages.has(pathname);
+}

--- a/src/lib/domains/PageInteraction/ViewRecorder.server.test.ts
+++ b/src/lib/domains/PageInteraction/ViewRecorder.server.test.ts
@@ -1,58 +1,149 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const pageViews = vi.hoisted(() => ({ upsertPageViews: vi.fn() }));
+import { recordPageView, type ViewGuardEnv } from "./ViewRecorder.server";
 
-vi.mock("@/lib/domains/PageViews", () => pageViews);
-
-import { recordPageView } from "./ViewRecorder.server";
+const origin = "https://sreetamdas.com";
+const initialTime = Date.parse("2026-09-08T10:00:00Z");
+let now = initialTime;
+function request(headers: Record<string, string> = {}) {
+	return new Request(`${origin}/_serverFn/record`, {
+		method: "POST",
+		headers: {
+			origin,
+			"sec-fetch-site": "same-origin",
+			"user-agent": "Mozilla/5.0 Chrome/140.0",
+			"cf-connecting-ip": "192.0.2.1",
+			...headers,
+		},
+	});
+}
+function limiter(limit: number, duration: number) {
+	const buckets = new Map<string, { start: number; count: number }>();
+	return {
+		limit: vi.fn(async ({ key }: { key: string }) => {
+			let bucket = buckets.get(key);
+			if (!bucket || now - bucket.start >= duration) {
+				bucket = { start: now, count: 0 };
+				buckets.set(key, bucket);
+			}
+			bucket.count++;
+			return { success: bucket.count <= limit };
+		}),
+	};
+}
+let budget = limiter(30, 60_000);
+let replay = limiter(1, 10_000);
+let env: ViewGuardEnv;
+const write = vi.fn(async (_slug: string) => {});
+const known = (slug: string) => ["/", "/about", "/blog/real-post"].includes(slug);
+const record = (slug = "/", req = request(), disabled = false) =>
+	recordPageView({ slug, disabled }, req, env, known, write, now);
 
 beforeEach(() => {
-	pageViews.upsertPageViews.mockReset().mockResolvedValue({ view_count: 12 });
+	now = initialTime;
+	budget = limiter(30, 60_000);
+	replay = limiter(1, 10_000);
+	env = {
+		ANALYTICS_ALLOWED_ORIGINS: origin,
+		LIKES_IP_SALT: "test-salt",
+		VIEW_RATE_LIMITER: budget,
+		VIEW_REPLAY_LIMITER: replay,
+	};
+	write.mockClear();
 });
 
-describe("recordPageView", () => {
-	test("records a page view for each valid call", async () => {
-		const result = await recordPageView(
-			{ slug: "/about?ignored=true", disabled: false },
-			pageViews.upsertPageViews,
-		);
-
-		expect(result).toEqual({ recorded: true });
-		expect(pageViews.upsertPageViews).toHaveBeenCalledWith("/about");
+describe("recordPageView server guard", () => {
+	test("normalizes query/trailing slash and suppresses immediate replay but counts later refreshes", async () => {
+		expect(await record("/about/?ignored=1")).toEqual({ recorded: true });
+		expect(await record("/about")).toEqual({ recorded: false });
+		now += 10_000;
+		expect(await record("/about")).toEqual({ recorded: true });
+		expect(write.mock.calls).toEqual([["/about"], ["/about"]]);
 	});
-
-	test("records refresh-like repeated calls as new views", async () => {
-		const firstResult = await recordPageView(
-			{ slug: "/about", disabled: false },
-			pageViews.upsertPageViews,
-		);
-		const secondResult = await recordPageView(
-			{ slug: "/about", disabled: false },
-			pageViews.upsertPageViews,
-		);
-
-		expect(firstResult).toEqual({ recorded: true });
-		expect(secondResult).toEqual({ recorded: true });
-		expect(pageViews.upsertPageViews).toHaveBeenCalledTimes(2);
+	test("permits another known page in the replay window", async () => {
+		expect((await record()).recorded).toBe(true);
+		expect((await record("/blog/real-post")).recorded).toBe(true);
 	});
-
-	test("does not write when the counter is disabled", async () => {
-		const result = await recordPageView(
-			{ slug: "/about", disabled: true },
-			pageViews.upsertPageViews,
-		);
-
-		expect(result).toEqual({ recorded: false });
-		expect(pageViews.upsertPageViews).not.toHaveBeenCalled();
+	test.each([
+		"/made-up",
+		"/api/presence",
+		"/assets/a",
+		"//evil.test/",
+		"/\\evil.test",
+		"/a\n",
+		"/" + "x".repeat(513),
+	])("rejects invalid/unknown %s before limiter or D1", async (slug) => {
+		expect(await record(slug)).toEqual({ recorded: false });
+		expect(budget.limit).not.toHaveBeenCalled();
+		expect(write).not.toHaveBeenCalled();
 	});
-
-	test("rejects invalid or non-page slugs before writing", async () => {
-		const result = await recordPageView(
-			{ slug: "/api/presence", disabled: false },
-			pageViews.upsertPageViews,
-		);
-
-		expect(result).toEqual({ recorded: false });
-		expect(pageViews.upsertPageViews).not.toHaveBeenCalled();
+	test.each([
+		{ origin: "" },
+		{ origin: "null" },
+		{ origin: "https://evil.test" },
+		{ "sec-fetch-site": "cross-site" },
+		{ "sec-fetch-site": "same-site" },
+		{ "sec-fetch-mode": "navigate" },
+		{ "sec-fetch-dest": "iframe" },
+		{ "user-agent": "" },
+		{ "user-agent": "Googlebot/2.1" },
+		{ "user-agent": "HeadlessChrome/100" },
+		{ "cf-connecting-ip": "", "x-forwarded-for": "192.0.2.4", "x-relay-ip": "192.0.2.4" },
+	])("rejects untrusted facts %j before limiter or D1", async (headers) => {
+		expect(await record("/", request(headers))).toEqual({ recorded: false });
+		expect(budget.limit).not.toHaveBeenCalled();
+		expect(write).not.toHaveBeenCalled();
+	});
+	test("disabled can only skip a write", async () => {
+		expect(await record("/", request(), true)).toEqual({ recorded: false });
+		expect(write).not.toHaveBeenCalled();
+	});
+	test.each([
+		"LIKES_IP_SALT",
+		"VIEW_RATE_LIMITER",
+		"VIEW_REPLAY_LIMITER",
+		"ANALYTICS_ALLOWED_ORIGINS",
+	])("fails closed without %s", async (binding) => {
+		Reflect.deleteProperty(env, binding);
+		expect(await record()).toEqual({ recorded: false });
+		expect(write).not.toHaveBeenCalled();
+	});
+	test("fails closed for either limiter failure/rejection", async () => {
+		budget.limit.mockRejectedValueOnce(new Error("unavailable"));
+		expect((await record()).recorded).toBe(false);
+		budget.limit.mockResolvedValueOnce({ success: false });
+		expect((await record()).recorded).toBe(false);
+		replay.limit.mockRejectedValueOnce(new Error("unavailable"));
+		expect((await record()).recorded).toBe(false);
+		replay.limit.mockResolvedValueOnce({ success: false });
+		expect((await record()).recorded).toBe(false);
+		expect(write).not.toHaveBeenCalled();
+	});
+	test("caps IP regardless of UA rotation and resets after the budget interval", async () => {
+		for (let index = 0; index < 31; index++) {
+			const result = await record("/", request({ "user-agent": `Mozilla Chrome/${index}` }));
+			expect(result.recorded).toBe(index < 30);
+		}
+		now += 60_000;
+		expect((await record()).recorded).toBe(true);
+		expect(write).toHaveBeenCalledTimes(31);
+	});
+	test("sends only keyed rotating pseudonyms to the bindings", async () => {
+		await record();
+		const key = budget.limit.mock.calls[0]?.[0].key;
+		const replayKey = replay.limit.mock.calls[0]?.[0].key;
+		expect(key).toMatch(/^[a-f0-9]{64}$/);
+		expect(replayKey).toMatch(/^[a-f0-9]{64}$/);
+		expect(key).not.toBe(replayKey);
+		now += 86_400_000;
+		await record();
+		expect(budget.limit.mock.calls[1]?.[0].key).not.toBe(key);
+		env.LIKES_IP_SALT = "rotated-salt";
+		await record();
+		expect(budget.limit.mock.calls[2]?.[0].key).not.toBe(budget.limit.mock.calls[1]?.[0].key);
+	});
+	test("does not report a failed D1 write as recorded", async () => {
+		write.mockRejectedValueOnce(new Error("D1 unavailable"));
+		expect(await record()).toEqual({ recorded: false });
 	});
 });

--- a/src/lib/domains/PageInteraction/ViewRecorder.server.test.ts
+++ b/src/lib/domains/PageInteraction/ViewRecorder.server.test.ts
@@ -77,7 +77,7 @@ describe("recordPageView server guard", () => {
 		expect(budget.limit).not.toHaveBeenCalled();
 		expect(write).not.toHaveBeenCalled();
 	});
-	test.each([
+	const untrusted: Array<Record<string, string>> = [
 		{ origin: "" },
 		{ origin: "null" },
 		{ origin: "https://evil.test" },
@@ -89,7 +89,8 @@ describe("recordPageView server guard", () => {
 		{ "user-agent": "Googlebot/2.1" },
 		{ "user-agent": "HeadlessChrome/100" },
 		{ "cf-connecting-ip": "", "x-forwarded-for": "192.0.2.4", "x-relay-ip": "192.0.2.4" },
-	])("rejects untrusted facts %j before limiter or D1", async (headers) => {
+	];
+	test.each(untrusted)("rejects untrusted facts %j before limiter or D1", async (headers) => {
 		expect(await record("/", request(headers))).toEqual({ recorded: false });
 		expect(budget.limit).not.toHaveBeenCalled();
 		expect(write).not.toHaveBeenCalled();

--- a/src/lib/domains/PageInteraction/ViewRecorder.server.ts
+++ b/src/lib/domains/PageInteraction/ViewRecorder.server.ts
@@ -1,72 +1,97 @@
 /**
- * Server-function page view recorder.
- *
- * Cached HTML cannot reliably run Worker document hooks, so hydrated pages call
- * this same-origin TanStack server function once per pathname. Refreshes should
- * count as new page views, so the server path validates the slug and writes once
- * for each valid call instead of applying visitor dedupe.
+ * Hydrated-page counter writes are checked entirely on the server. Approximate
+ * edge budgets suppress rapid replay; refresh/return visits outside the short
+ * window still count. The client disabled flag can only opt out, never bypass.
  */
 import { createServerFn, createServerOnlyFn } from "@tanstack/react-start";
 
+import { isAllowedBrowserWrite, isAutomatedBrowser } from "@/lib/analytics/browser-request";
 import { normalizePathname } from "@/lib/helpers/utils";
 
-import {
-	type PagePathnamePayload,
-	validatePagePathnamePayload,
-	warnCounterFailureOnce,
-} from "./shared";
+import { type PagePathnamePayload, validatePagePathnamePayload } from "./shared";
 
-const MAX_SLUG_LENGTH = 512;
-
-type ViewWrite = (normalizedSlug: string) => Promise<void>;
-
-export type PageViewRecordResult = {
-	recorded: boolean;
+export type PageViewRecordResult = { recorded: boolean };
+export type ViewGuardEnv = {
+	ANALYTICS_ALLOWED_ORIGINS?: string;
+	LIKES_IP_SALT?: string;
+	VIEW_RATE_LIMITER?: Pick<RateLimit, "limit">;
+	VIEW_REPLAY_LIMITER?: Pick<RateLimit, "limit">;
 };
 
-export const recordPageViewServerFn = createServerFn({
-	method: "POST",
-})
-	.validator((data) => {
-		return validatePagePathnamePayload(data, "Invalid page view record payload");
-	})
-	.handler(async ({ data }) => {
-		return await recordPageView(data, upsertPageViewInDb);
-	});
+export const recordPageViewServerFn = createServerFn({ method: "POST" })
+	.validator((data) => validatePagePathnamePayload(data, "Invalid page view record payload"))
+	.handler(async ({ data }) => recordPageViewFromRequest(data));
+
+const recordPageViewFromRequest = createServerOnlyFn(async (data: PagePathnamePayload) => {
+	const { recordPageViewInDb } = await import("./ViewRecorder.data.server");
+	return recordPageViewInDb(data);
+});
 
 export async function recordPageView(
 	data: PagePathnamePayload,
-	writeView: ViewWrite = upsertPageViewInDb,
+	request: Request,
+	env: ViewGuardEnv,
+	isKnownPage: (pathname: string) => boolean,
+	writeView: (pathname: string) => Promise<void>,
+	nowMs = Date.now(),
 ): Promise<PageViewRecordResult> {
-	const normalizedSlug = normalizeViewSlug(data.slug);
-	if (data.disabled || !normalizedSlug) {
-		return { recorded: false };
-	}
-
 	try {
-		await writeView(normalizedSlug);
+		if (data.disabled || !isAllowedBrowserWrite(request, env.ANALYTICS_ALLOWED_ORIGINS)) {
+			return { recorded: false };
+		}
+		const slug = normalizeViewSlug(data.slug);
+		if (!slug || !isKnownPage(slug)) return { recorded: false };
+		const ua = request.headers.get("user-agent") ?? "";
+		const ip = request.headers.get("cf-connecting-ip");
+		if (isAutomatedBrowser(ua) || !ip || ip.length > 64) return { recorded: false };
+		const secret = env.LIKES_IP_SALT;
+		if (!secret?.trim() || !env.VIEW_RATE_LIMITER || !env.VIEW_REPLAY_LIMITER) {
+			return { recorded: false };
+		}
+		const day = new Date(nowMs).toISOString().slice(0, 10);
+		const origin = request.headers.get("origin");
+		const key = await crypto.subtle.importKey(
+			"raw",
+			new TextEncoder().encode(secret),
+			{ name: "HMAC", hash: "SHA-256" },
+			false,
+			["sign"],
+		);
+		const budgetKey = await viewKey(key, ["view-budget:v1", day, origin, ip]);
+		if (!(await env.VIEW_RATE_LIMITER.limit({ key: budgetKey })).success) {
+			return { recorded: false };
+		}
+		const replayKey = await viewKey(key, ["view-replay:v1", day, origin, ip, ua, slug]);
+		if (!(await env.VIEW_REPLAY_LIMITER.limit({ key: replayKey })).success) {
+			return { recorded: false };
+		}
+		await writeView(slug);
 		return { recorded: true };
-	} catch (error) {
-		warnCounterFailureOnce("record page view", error);
+	} catch {
+		// Never log request facts or exceptions potentially containing them.
 		return { recorded: false };
 	}
 }
 
-const upsertPageViewInDb = createServerOnlyFn(async (normalizedSlug: string): Promise<void> => {
-	const { getDb } = await import("@/db");
-	const { upsertPageViews } = await import("@/lib/domains/PageViews");
-	await upsertPageViews(getDb(), normalizedSlug);
-});
+async function viewKey(key: CryptoKey, facts: Array<string | null>): Promise<string> {
+	const digest = await crypto.subtle.sign(
+		"HMAC",
+		key,
+		new TextEncoder().encode(JSON.stringify(facts)),
+	);
+	return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
 
 function normalizeViewSlug(slug: string): string | undefined {
-	if (slug.length > MAX_SLUG_LENGTH || !slug.startsWith("/") || slug.startsWith("//")) {
+	if (slug.length > 512 || !slug.startsWith("/") || slug.startsWith("//")) {
 		return undefined;
 	}
-
+	for (const character of slug) {
+		const code = character.charCodeAt(0);
+		if (character === "\\" || code < 0x20 || code === 0x7f) {
+			return undefined;
+		}
+	}
 	const url = new URL(slug, "https://sreetamdas.com");
-	if (url.pathname.startsWith("/api/") || url.pathname.startsWith("/assets/")) {
-		return undefined;
-	}
-
 	return normalizePathname(url.pathname);
 }

--- a/src/lib/domains/PageInteraction/ViewsCounter.data.server.ts
+++ b/src/lib/domains/PageInteraction/ViewsCounter.data.server.ts
@@ -1,11 +1,8 @@
 /**
- * Client-readable page view count. Read-only by design: the increment must not
- * live on a client-callable server fn — that was replayable by any HTTP client
- * (`Origin` spoofing defeats the CSRF middleware) and inflated counters. The
- * view *write* now happens server-side on the Worker document-request path with
- * per-visitor dedup. Here `disabled` is accepted to preserve the shared
- * page-interaction payload/validator contract but is intentionally ignored on
- * the view path; it still gates the like path.
+ * Client-readable page view count, read-only by design. Hydrated pages write
+ * separately through ViewRecorder.server.ts: server origin/content/bot checks
+ * and approximate edge replay/rate budgets run before the D1 increment.
+ * `disabled` is intentionally ignored on this read-only path.
  */
 import "@tanstack/react-start/server-only";
 import { getDb } from "@/db";

--- a/src/routes/(api)/api/analytics/-event.test.ts
+++ b/src/routes/(api)/api/analytics/-event.test.ts
@@ -1,57 +1,107 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const cloudflare = vi.hoisted<{ env: Record<string, unknown> }>(() => ({ env: {} }));
 vi.mock("cloudflare:workers", () => cloudflare);
 
+import { handleAnalyticsEventPost as handleAliasPost } from "../prxy/nltyx/event";
 import { handleAnalyticsEventGet, handleAnalyticsEventPost } from "./event";
 
-describe("native analytics event route", () => {
-	test("rejects GET", () => {
-		const response = handleAnalyticsEventGet();
-		expect(response.status).toBe(405);
-		expect(response.headers.get("allow")).toBe("POST");
+const origin = "https://sreetamdas.com";
+const fetch = vi.fn(
+	async (_url: string, _init?: RequestInit) => new Response(null, { status: 202 }),
+);
+function request(headers: Record<string, string> = {}) {
+	return new Request(`${origin}/api/analytics/event`, {
+		method: "POST",
+		headers: { origin, "cf-connecting-ip": "192.0.2.1", "user-agent": "browser", ...headers },
+		body: '{"name":"pageview"}',
 	});
+}
+beforeEach(() => {
+	fetch.mockClear();
+	cloudflare.env = {
+		STATS: { fetch },
+		RELAY_TOKEN: "secret",
+		ANALYTICS_PROJECT_SLUG: "site",
+		ANALYTICS_ALLOWED_ORIGINS: origin,
+	};
+});
 
-	test("relays the unchanged body and transient facts", async () => {
-		const fetch = vi.fn((_url: string, init?: RequestInit) => {
-			expect(init?.body).toBeInstanceOf(ReadableStream);
+describe.each([handleAnalyticsEventPost, handleAliasPost])(
+	"first-party analytics relay %s",
+	(post) => {
+		test("rejects GET", () => {
+			const response = handleAnalyticsEventGet();
+			expect(response.status).toBe(405);
+			expect(response.headers.get("allow")).toBe("POST");
+		});
+		test("relays unchanged body with only trusted facts", async () => {
+			const req = request({
+				"x-relay-token": "forged",
+				"x-relay-ip": "forged",
+				"x-forwarded-for": "forged",
+				"x-relay-country": "forged",
+			});
+			expect((await post(req)).status).toBe(202);
+			const init = fetch.mock.calls[0]?.[1];
+			expect(init?.body).toBe(req.body);
 			const headers = new Headers(init?.headers);
 			expect(headers.get("x-relay-token")).toBe("secret");
 			expect(headers.get("x-relay-ip")).toBe("192.0.2.1");
-			return Promise.resolve(new Response(null, { status: 202 }));
+			expect(headers.get("x-relay-country")).toBe("");
+			expect(headers.has("x-forwarded-for")).toBe(false);
 		});
-		cloudflare.env = {
-			STATS: { fetch },
-			RELAY_TOKEN: "secret",
-			ANALYTICS_PROJECT_SLUG: "site",
-		};
-		const response = await handleAnalyticsEventPost(
-			new Request("https://example.com/api/analytics/event", {
-				method: "POST",
-				headers: { "cf-connecting-ip": "192.0.2.1", "user-agent": "test" },
-				body: '{"name":"pageview"}',
-			}),
-		);
-		expect(response.status).toBe(202);
-	});
-
-	test("does not fabricate a client IP when the request has none", async () => {
-		const fetch = vi.fn((_url: string, init?: RequestInit) => {
-			const headers = new Headers(init?.headers);
-			expect(headers.has("x-relay-ip")).toBe(false);
-			return Promise.resolve(new Response(null, { status: 202 }));
+		test.each([
+			{ origin: "" },
+			{ origin: "null" },
+			{ origin: "https://evil.test" },
+			{ origin: "https://sreetamdas.com.evil.test" },
+			{ "sec-fetch-site": "cross-site" },
+			{ "sec-fetch-site": "same-site" },
+			{ "sec-fetch-mode": "navigate" },
+			{ "sec-fetch-dest": "image" },
+		])("rejects %j before touching body or service", async (headers) => {
+			const req = request(headers);
+			const body = vi.spyOn(req, "body", "get");
+			expect((await post(req)).status).toBe(403);
+			expect(body).not.toHaveBeenCalled();
+			expect(fetch).not.toHaveBeenCalled();
 		});
-		cloudflare.env = {
-			STATS: { fetch },
-			RELAY_TOKEN: "secret",
-			ANALYTICS_PROJECT_SLUG: "site",
-		};
-		const response = await handleAnalyticsEventPost(
-			new Request("https://example.com/api/analytics/event", {
+		test("fails closed with no configured origins", async () => {
+			delete cloudflare.env.ANALYTICS_ALLOWED_ORIGINS;
+			expect((await post(request())).status).toBe(403);
+			expect(fetch).not.toHaveBeenCalled();
+		});
+		test("does not trust attacker-selected request host or forwarded host", async () => {
+			const req = new Request("https://evil.test/api/analytics/event", {
 				method: "POST",
-				body: '{"name":"pageview"}',
-			}),
-		);
-		expect(response.status).toBe(202);
-	});
-});
+				headers: { origin: "https://evil.test", "x-forwarded-host": "sreetamdas.com" },
+			});
+			expect((await post(req)).status).toBe(403);
+			expect(fetch).not.toHaveBeenCalled();
+		});
+		test.each([
+			"https://staging.sreetamdas.com",
+			"https://dev.sreetamdas.com",
+			"http://localhost:3000",
+		])("supports explicitly configured %s", async (site) => {
+			cloudflare.env.ANALYTICS_ALLOWED_ORIGINS = site;
+			expect(
+				(
+					await post(
+						new Request(`${site}/api/analytics/event`, {
+							method: "POST",
+							headers: { origin: site },
+						}),
+					)
+				).status,
+			).toBe(202);
+		});
+		test("does not fabricate a client IP", async () => {
+			const req = request();
+			req.headers.delete("cf-connecting-ip");
+			expect((await post(req)).status).toBe(202);
+			expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).has("x-relay-ip")).toBe(false);
+		});
+	},
+);

--- a/src/routes/(api)/api/analytics/-event.test.ts
+++ b/src/routes/(api)/api/analytics/-event.test.ts
@@ -51,7 +51,7 @@ describe.each([handleAnalyticsEventPost, handleAliasPost])(
 			expect(headers.get("x-relay-country")).toBe("");
 			expect(headers.has("x-forwarded-for")).toBe(false);
 		});
-		test.each([
+		const foreign: Array<Record<string, string>> = [
 			{ origin: "" },
 			{ origin: "null" },
 			{ origin: "https://evil.test" },
@@ -60,7 +60,8 @@ describe.each([handleAnalyticsEventPost, handleAliasPost])(
 			{ "sec-fetch-site": "same-site" },
 			{ "sec-fetch-mode": "navigate" },
 			{ "sec-fetch-dest": "image" },
-		])("rejects %j before touching body or service", async (headers) => {
+		];
+		test.each(foreign)("rejects %j before touching body or service", async (headers) => {
 			const req = request(headers);
 			const body = vi.spyOn(req, "body", "get");
 			expect((await post(req)).status).toBe(403);

--- a/src/routes/(api)/api/analytics/event.ts
+++ b/src/routes/(api)/api/analytics/event.ts
@@ -1,48 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { env } from "cloudflare:workers";
 
-export function handleAnalyticsEventGet(): Response {
-	return new Response("Method not allowed", {
-		status: 405,
-		headers: { Allow: "POST" },
-	});
-}
+import { handleAnalyticsEventGet, handleAnalyticsEventPost } from "@/lib/analytics/event.server";
 
-export async function handleAnalyticsEventPost(request: Request): Promise<Response> {
-	const relayToken =
-		"RELAY_TOKEN" in env && typeof env.RELAY_TOKEN === "string" ? env.RELAY_TOKEN : "";
-	const projectSlug =
-		"ANALYTICS_PROJECT_SLUG" in env && typeof env.ANALYTICS_PROJECT_SLUG === "string"
-			? env.ANALYTICS_PROJECT_SLUG
-			: "";
-	if (relayToken.trim() === "" || projectSlug.trim() === "") {
-		return new Response("Analytics unavailable", { status: 503 });
-	}
-
-	const cf = request.cf;
-	const ip = request.headers.get("cf-connecting-ip");
-	try {
-		const response = await env.STATS.fetch(
-			`https://stats.internal/v1/relay/${encodeURIComponent(projectSlug)}`,
-			{
-				method: "POST",
-				headers: {
-					"content-type": request.headers.get("content-type") ?? "text/plain;charset=UTF-8",
-					"x-relay-token": relayToken,
-					"x-relay-ua": request.headers.get("user-agent") ?? "",
-					"x-relay-country": typeof cf?.country === "string" ? cf.country : "",
-					"x-relay-city": typeof cf?.city === "string" ? cf.city : "",
-					...(ip === null ? {} : { "x-relay-ip": ip }),
-				},
-				body: request.body,
-			},
-		);
-		if (response.status === 202) return new Response(null, { status: 202 });
-		return new Response("Analytics rejected", { status: 502 });
-	} catch {
-		return new Response("Analytics unavailable", { status: 502 });
-	}
-}
+export { handleAnalyticsEventGet, handleAnalyticsEventPost };
 
 export const Route = createFileRoute("/(api)/api/analytics/event")({
 	server: {

--- a/src/routes/(api)/api/prxy/nltyx/event.ts
+++ b/src/routes/(api)/api/prxy/nltyx/event.ts
@@ -1,48 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { env } from "cloudflare:workers";
 
-export function handleAnalyticsEventGet(): Response {
-	return new Response("Method not allowed", {
-		status: 405,
-		headers: { Allow: "POST" },
-	});
-}
+import { handleAnalyticsEventGet, handleAnalyticsEventPost } from "@/lib/analytics/event.server";
 
-export async function handleAnalyticsEventPost(request: Request): Promise<Response> {
-	const relayToken =
-		"RELAY_TOKEN" in env && typeof env.RELAY_TOKEN === "string" ? env.RELAY_TOKEN : "";
-	const projectSlug =
-		"ANALYTICS_PROJECT_SLUG" in env && typeof env.ANALYTICS_PROJECT_SLUG === "string"
-			? env.ANALYTICS_PROJECT_SLUG
-			: "";
-	if (relayToken.trim() === "" || projectSlug.trim() === "") {
-		return new Response("Analytics unavailable", { status: 503 });
-	}
-
-	const cf = request.cf;
-	const ip = request.headers.get("cf-connecting-ip");
-	try {
-		const response = await env.STATS.fetch(
-			`https://stats.internal/v1/relay/${encodeURIComponent(projectSlug)}`,
-			{
-				method: "POST",
-				headers: {
-					"content-type": request.headers.get("content-type") ?? "text/plain;charset=UTF-8",
-					"x-relay-token": relayToken,
-					"x-relay-ua": request.headers.get("user-agent") ?? "",
-					"x-relay-country": typeof cf?.country === "string" ? cf.country : "",
-					"x-relay-city": typeof cf?.city === "string" ? cf.city : "",
-					...(ip === null ? {} : { "x-relay-ip": ip }),
-				},
-				body: request.body,
-			},
-		);
-		if (response.status === 202) return new Response(null, { status: 202 });
-		return new Response("Analytics rejected", { status: 502 });
-	} catch {
-		return new Response("Analytics unavailable", { status: 502 });
-	}
-}
+export { handleAnalyticsEventGet, handleAnalyticsEventPost };
 
 export const Route = createFileRoute("/(api)/api/prxy/nltyx/event")({
 	server: {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -64,7 +64,8 @@
 		}
 	],
 	"vars": {
-		"ANALYTICS_PROJECT_SLUG": "sreetamdas-com-prod"
+		"ANALYTICS_PROJECT_SLUG": "sreetamdas-com-prod",
+		"ANALYTICS_ALLOWED_ORIGINS": "https://sreetamdas.com,http://localhost:3000,http://localhost:5173"
 	},
 	"kv_namespaces": [
 		{
@@ -76,7 +77,8 @@
 	"env": {
 		"staging": {
 			"vars": {
-				"ANALYTICS_PROJECT_SLUG": "sreetamdas-com-staging"
+				"ANALYTICS_PROJECT_SLUG": "sreetamdas-com-staging",
+				"ANALYTICS_ALLOWED_ORIGINS": "https://dev.sreetamdas.com,https://staging.sreetamdas.com"
 			},
 			"services": [
 				{
@@ -135,11 +137,30 @@
 					"id": "2bc6cd0487714be58807514bc7c2003b",
 					"preview_id": "sreetamdas_com_kv_preview_staging"
 				}
+			],
+			"ratelimits": [
+				{
+					"name": "VIEW_RATE_LIMITER",
+					"namespace_id": "2103",
+					"simple": {
+						"limit": 30,
+						"period": 60
+					}
+				},
+				{
+					"name": "VIEW_REPLAY_LIMITER",
+					"namespace_id": "2104",
+					"simple": {
+						"limit": 1,
+						"period": 10
+					}
+				}
 			]
 		},
 		"production": {
 			"vars": {
-				"ANALYTICS_PROJECT_SLUG": "sreetamdas-com-prod"
+				"ANALYTICS_PROJECT_SLUG": "sreetamdas-com-prod",
+				"ANALYTICS_ALLOWED_ORIGINS": "https://sreetamdas.com"
 			},
 			"services": [
 				{
@@ -194,7 +215,43 @@
 					"id": "2bc6cd0487714be58807514bc7c2003b",
 					"preview_id": "sreetamdas_com_kv_preview_production"
 				}
+			],
+			"ratelimits": [
+				{
+					"name": "VIEW_RATE_LIMITER",
+					"namespace_id": "2105",
+					"simple": {
+						"limit": 30,
+						"period": 60
+					}
+				},
+				{
+					"name": "VIEW_REPLAY_LIMITER",
+					"namespace_id": "2106",
+					"simple": {
+						"limit": 1,
+						"period": 10
+					}
+				}
 			]
 		}
-	}
+	},
+	"ratelimits": [
+		{
+			"name": "VIEW_RATE_LIMITER",
+			"namespace_id": "2101",
+			"simple": {
+				"limit": 30,
+				"period": 60
+			}
+		},
+		{
+			"name": "VIEW_REPLAY_LIMITER",
+			"namespace_id": "2102",
+			"simple": {
+				"limit": 1,
+				"period": 10
+			}
+		}
+	]
 }


### PR DESCRIPTION
## Background

The homepage view counter (page_details) read 922,208 vs ~28,884 imported Plausible pageviews — the recorder accepted every valid POST with no server-side budget, and both analytics proxy routes forwarded arbitrary bodies (with the server-held relay token) without an origin check. Full investigation and review notes: https://gist.github.com/sreetamdas/8752cb152b89c25ccc477c5ccb16c38f

## What

**View counter hardening** (`ViewRecorder`)
- Server-side guards before D1: exact configured origin + fetch metadata, known-published-page allowlist, bot/UA rejection, fail-closed on missing secrets/limiters
- Two edge budgets: 30 views/IP/min and 1 view/page/10s, keyed by daily HMACs over `LIKES_IP_SALT` — no raw IP/UA stored or logged
- Tradeoff (documented): rapid refreshes may undercount; NAT clients share budget; approximate per-colo suppression is not exact dedupe

**Analytics proxy guard** (`/api/analytics/event`, `/api/prxy/nltyx/event`)
- Shared `browser-request` guard rejects foreign-origin submissions before the body or service binding is used (closes the drive-by pageview injection hole)

**Config**
- `VIEW_RATE_LIMITER` (30/60s) and `VIEW_REPLAY_LIMITER` (1/10s) with distinct namespace ids per environment (2101–2106)
- `ANALYTICS_ALLOWED_ORIGINS` per environment (prod: `https://sreetamdas.com` only)

**Data correction (already applied to prod D1, not in this diff)**
- Homepage counter reset 922,208 → 28,178 = 28,096 imported baseline + 82 native views; likes preserved

## Deployment checklist

- [ ] `LIKES_IP_SALT` + `RELAY_TOKEN` secrets present in staging/prod (guards fail closed otherwise — a sudden telemetry drop is the failure signal)
- [ ] Rate-limit binding namespaces 2101–2106 are free
- [ ] Verify homepage still records views (recording continues even though PR #293 hides the homepage display)

## Verification

- `pnpm vitest run`: 376 passed (incl. reworked recorder/proxy suites and new guard tests)
- `pnpm lint`: clean
- Staging smoke recommended after deploy (origin allowlist differs per env — staging expects `https://staging.sreetamdas.com` / `https://dev.sreetamdas.com`)
