### PR TITLE
fix(karma): point showcase palette at canonical theme tokens

### DIFF
--- a/src/lib/components/KarmaShowcase.tsx
+++ b/src/lib/components/KarmaShowcase.tsx
@@ -7,9 +7,9 @@ import { Image } from "@/lib/components/Image";
 
 const KARMA_COLOR_PALETTE = [
 	"#FC618D",
-	"#51C7DA",
+	"#5AD4E6",
 	"#AF98E6",
-	"#E3CF65",
+	"#FCE566",
 	"#7BD88F",
 	"#FD9353",
 ] as const;
@@ -17,7 +17,7 @@ const KARMA_LIGHT_COLOR_PALETTE = [
 	"#FC618D",
 	"#5688C7",
 	"#6F42C1",
-	"#FFAA33",
+	"#EEAE11",
 	"#2D972F",
 	"#FA8D3E",
 ] as const;


### PR DESCRIPTION
## Proposed Changes

- **Dark palette** — `KARMA_COLOR_PALETTE` had two stale hexes for the blue/yellow accent roles:
  - `#51C7DA` → `#5AD4E6` (theme `blue`; `#51C7DA` only survives in the deliberately-shipped *Karma Legacy* theme)
  - `#E3CF65` → `#FCE566` (theme `yellow`; `#E3CF65` is `yellowButDarker`, a syntax-tier token)
- **Light palette** — same role error in one slot: `#FFAA33` → `#EEAE11` (`yellow`, not `yellowButDarker`).
- The other four roles (red/purple/green/orange) were already correct.

Canon is the karma repo's `src/tokens.ts`: `blue: #5AD4E6`, `yellow: #FCE566`, `yellowButDarker: #E3CF65`.

## Verification

- Confirmed user-visible drift: `https://sreetamdas.com/karma` currently serves `51C7DA` ×2 and `E3CF65` ×2, and **zero** occurrences of `5AD4E6` / `FCE566`.
- `vp fmt --check` and `vp lint` on the changed file both pass.
- 3-line diff, one file; no other source file in the repo still references the legacy hexes.

## Follow-up (not in this PR)

The palette is hardcoded here, which is how it drifted. `@sreetamdas/karma` only exports `defaultTheme` / `lightTheme` — exporting the `KARMA` tokens upstream would let this component import the palette instead.
