### PR TITLE
chore: opt into the new workerd module registry

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,7 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "sreetamdas-com",
 	"compatibility_date": "2026-06-16",
-	"compatibility_flags": ["nodejs_compat"],
+	"compatibility_flags": ["nodejs_compat", "new_module_registry"],
 	"main": "./src/worker.ts",
 	"workers_dev": true,
 	"preview_urls": true,


### PR DESCRIPTION
## What

Adds the `new_module_registry` compatibility flag to `wrangler.jsonc`. The diff is one line.

Cloudflare sets no default date for this flag, so a Worker must name it to get it.

The flag selects the rewritten workerd module registry. That registry resolves specifiers as URLs. It supports `import.meta.url`, `import.meta.main` and `import.meta.resolve`. It follows the Node.js rules for `require(esm)`, and it enforces the rules for import attributes. It compiles a module when the runtime first imports it, and it shares the module cache across isolates. The old registry compiled the whole bundle at startup and kept a private copy in each isolate.

## Rollout

One flag covers every environment, because neither `env.staging` nor `env.production` overrides `compatibility_flags`. That gives a staged rollout:

1. A branch deploy runs `npx wrangler versions upload`. It makes a preview version, not a production release.
2. The merge to `main` runs `npx wrangler deploy`. Production takes the flag only at that point.

## Verification

- `JSON.parse` reads `wrangler.jsonc` without an error. The file stays strict JSON.
- The flag list resolves to `["nodejs_compat","new_module_registry"]`.
- `env.staging` and `env.production` both inherit the list.
- Local `pnpm build` completes and prerenders every route.
- Local `pnpm test:unit` passes 349 tests across 50 files.

## Notes

Do not add comments to `wrangler.jsonc`. `scripts/deploy-preview.mjs` reads the file with `JSON.parse`, so a comment stops every `dev` staging deploy. The file has the `.jsonc` extension, but this repository treats it as strict JSON.

The flag makes import attribute validation strict. An import attribute that the old registry ignored now stops the load with a `TypeError`. A future dependency bump can fail at deploy for this reason.

This change gives no measured speed gain. A trial on a comparable Worker with the Vite plugin showed no clear difference. Merge it for correct behavior and a shorter path to the default, not for speed.
