### PR TITLE
chore(ci): start every job at once and cut the pipeline in half

### DIFF
--- a/.config/playwright.config.ts
+++ b/.config/playwright.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
 	fullyParallel: true,
 	forbidOnly: Boolean(process.env.CI),
 	retries: process.env.CI ? 2 : 0,
-	workers: process.env.CI ? 2 : undefined,
+	// A ubuntu-latest runner has 4 cores. Two workers left half of them idle,
+	// and retries stay at 2 to absorb any contention the extra workers add.
+	workers: process.env.CI ? 4 : undefined,
 	reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
 	use: {
 		baseURL: "http://127.0.0.1:5045",

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -9,6 +9,20 @@ runs:
       with:
         node-version-file: .node-version
 
+    - name: Get pnpm version
+      id: pnpm-version
+      shell: bash
+      run: echo "version=$(node -p 'require("./package.json").packageManager')" >> "$GITHUB_OUTPUT"
+
+    # `corepack prepare` downloads a 37MB pnpm tarball when the cache is cold.
+    # The key tracks the pinned pnpm version only, so a hit lasts until the
+    # version changes and the save step is skipped on every hit.
+    - name: Cache Corepack
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/node/corepack
+        key: ${{ runner.os }}-corepack-${{ steps.pnpm-version.outputs.version }}
+
     - name: Enable Corepack
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Every job generates what it needs with `pnpm prebuild` (two to three seconds)
+# instead of downloading an artifact. The old artifact plumbing made `lint` a
+# gate on `build`, `unit-tests` and `worker-tests`, which put a 45s job on the
+# critical path to save a 3s step. No job depends on another one now, so all
+# five start together.
+
 jobs:
   typecheck:
     name: Typecheck
@@ -28,11 +34,10 @@ jobs:
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
 
-      - name: Generate build info
-        run: node scripts/generate-build-info.mjs
-
-      - name: Build content
-        run: pnpm run build:content-collections
+      # tsc resolves `content-collections` and `@/build-info.json`, so it needs
+      # the generated files on disk before it runs.
+      - name: Generate content, feeds and build info
+        run: pnpm prebuild
 
       - name: Typecheck
         run: pnpm run typecheck:ci
@@ -48,27 +53,9 @@ jobs:
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
 
-      - name: Generate build info
-        run: node scripts/generate-build-info.mjs
-
-      - name: Build content
-        run: pnpm run build:content-collections
-
-      - name: Generate feeds
-        run: pnpm run generate-feeds
-
-      - name: Upload generated assets
-        uses: actions/upload-artifact@v7
-        with:
-          name: generated-assets
-          path: |
-            .content-collections/
-            public/rss/
-            src/build-info.json
-          if-no-files-found: error
-          include-hidden-files: true
-          retention-days: 1
-
+      # Lint needs no generation step: `vp` builds content collections on demand
+      # and neither oxfmt nor oxlint resolve imports. Verified against a tree
+      # with no .content-collections.
       - name: Lint
         run: pnpm lint
 
@@ -76,7 +63,6 @@ jobs:
     name: Unit/API Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [typecheck, lint]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -84,11 +70,8 @@ jobs:
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
 
-      - name: Download generated assets
-        uses: actions/download-artifact@v8
-        with:
-          name: generated-assets
-          path: .
+      - name: Generate content, feeds and build info
+        run: pnpm prebuild
 
       - name: Run unit/api tests
         run: pnpm test:unit
@@ -97,7 +80,6 @@ jobs:
     name: Worker Runtime Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [typecheck, lint]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -108,11 +90,13 @@ jobs:
       - name: Run worker runtime tests
         run: pnpm test:workers
 
-  build:
-    name: Build
+  # Build and E2E share a job. Splitting them meant paying `Setup pnpm` twice
+  # (about 24s) plus a job scheduling barrier, to hand one directory to the next
+  # job. The E2E suite runs against the `dist/` this job just produced.
+  build-and-e2e:
+    name: Build & E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: [typecheck, lint]
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -120,52 +104,33 @@ jobs:
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
 
-      - name: Download generated assets
-        uses: actions/download-artifact@v8
-        with:
-          name: generated-assets
-          path: .
+      - name: Generate content, feeds and build info
+        run: pnpm prebuild
 
       - name: Build
         run: pnpm run build:ci
         env:
           VITE_CI: "1"
 
-      - name: Upload build output
-        uses: actions/upload-artifact@v7
-        with:
-          name: build-output
-          path: |
-            dist/
-            .wrangler/deploy/
-          if-no-files-found: error
-          include-hidden-files: true
-          retention-days: 1
-
-      - name: Upload build artifacts on failure
+      - name: Upload build output on failure
         uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: build-output-failed
           path: dist/
 
-  e2e:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: [build, unit-tests, worker-tests]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
-      - name: Setup pnpm
-        uses: ./.github/actions/setup-pnpm
-
-      - name: Download build output
-        uses: actions/download-artifact@v8
+      # Without this, `playwright install` downloads Chromium on every run: 21s
+      # of the E2E job. The key holds no restore-keys on purpose, because an
+      # older browser revision must not satisfy a newer Playwright.
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          name: build-output
-          path: .
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-ms-playwright-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright
         run: pnpm exec playwright install --with-deps chromium


### PR DESCRIPTION
## What

No job waits on another one now.

Every job generates its own inputs with `pnpm prebuild`, which takes two to three seconds. The `generated-assets` artifact is gone. `build` and `e2e` share one job. Playwright browsers come from `actions/cache`.

## Effect

Measured on this branch, against the same numbers from `main` (run [34609322937](https://github.com/sreetamdas/sreetamdas.com/actions/runs/34609322937)).

| | main | this PR (cold browser cache) | this PR (warm) |
|---|---|---|---|
| Wall clock | 193s | 121s | 97s |
| Total runner time | 279s | 273s | 256s |
| Longest job | 78s (E2E Tests) | 116s (Build & E2E Tests) | 92s (Build & E2E Tests) |

The longest job is longer than before, because it is now two jobs in one. That is the point: `build` and `e2e` used to run one after the other and finish at 130s together.

The first run on a branch is slow while the Playwright cache is cold.

## Why

The old pipeline ran for 193 seconds. `Setup pnpm` costs 22 to 26 seconds, and six jobs paid it. That is 145 of the 279 seconds of runner time.

The `generated-assets` artifact was the only reason `build`, `unit-tests` and `worker-tests` waited about 45 seconds for `lint` to finish. That artifact carried content collections, feeds and build info, and those take two to three seconds to build from scratch. The gate cost much more than the artifact saved.

`e2e` needed one directory from `build`. The `needs: [build]` key charged a second `Setup pnpm` for that directory, plus a scheduling barrier.

## Verification

- `actionlint` reports nothing on `.github/workflows/ci.yml` or on the repository.
- This branch ran green twice, once with a cold Playwright cache and once warm.
- `pnpm prebuild && pnpm run build:ci` builds `dist/` from a clean tree. The resume PDF sync check passes.
- `pnpm prebuild && pnpm test:unit` passes.
- `pnpm test:workers` passes with no generation step, as before.
- `pnpm lint` passes on a tree with no `.content-collections`. This is why `lint` no longer generates anything.
- `pnpm run typecheck:ci` fails without `pnpm prebuild`, because it cannot resolve `content-collections` or `@/build-info.json`. Every job that needs types runs the step.

## Notes

`Install Playwright` still costs 13 seconds on a warm cache, because `--with-deps` installs operating system libraries with apt on every run. The browser download, which was the other 8 seconds, now comes from the cache. I kept `--with-deps` because Playwright documents it for CI and skipping it risks a missing library.

Playwright workers go from 2 to 4, and this bought almost nothing: the suite went from 29 to 26 seconds. The time sits in the preview server and the `db:migrate:local` step, not in test parallelism. Revert it if the extra concurrency ever causes a flake.

Do not add a `needs:` key without a real dependency. A `needs:` key costs a whole job barrier, and a new job costs another 22 to 26 seconds of `Setup pnpm`.

## Not in this PR

The four check jobs can become one, which saves about 100 more seconds of runner time. I left it out, because it hides a lint failure behind a test failure. It does not change the wall clock either, because those jobs sit under the 92 second critical path.

Caching `node_modules` is not worth it. The directory is 1.5GB, and a warm store already gets `pnpm install` to 11 seconds from a clean tree.
